### PR TITLE
Issue 362 - Conserta erro quando Content-length é None

### DIFF
--- a/src/crawling_utils/crawling_utils/crawling_utils.py
+++ b/src/crawling_utils/crawling_utils/crawling_utils.py
@@ -20,7 +20,11 @@ def file_larger_than_giga(url):
     response = requests.head(url, allow_redirects=True, headers=headers)
 
     # obtem o tamanho do arquivo e converte para inteiro
-    content_length = int(response.headers['Content-Length'])
+    content_length = response.headers.get('Content-Length')
+    if content_length is None:
+        return True
+
+    content_length = int(content_length)
 
     return content_length > 1e9
 


### PR DESCRIPTION
Ao fazer download de um arquivo, o campo "Content-length" é esperado no cabeçalho da resposta, mas nem sempre é fornecido. Nesse caso, o download dos arquivos falha. Essa PR adiciona o tratamento nesse caso.

Closes #362.