### PR TITLE
Issue-428: Corrigir funcionamento mecanismo de download de grandes arquivos

### DIFF
--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -264,6 +264,9 @@ class StaticPageSpider(BaseSpider):
         self.store_html(response)
         
         urls = set()
+        urls_small_file_content = set()
+        urls_large_file_content = set()
+
         if "explore_links" in config and config["explore_links"]:
             this_url = response.url
             urls = self.extract_links(response)


### PR DESCRIPTION
Quando o download de arquivos estava definido para `False`, duas variáveis ficavam indefinidas (pois era criadas numa condicional) e são usadas em outros trechos, gerando uma exceção. Essa PR corrige isso, ao definir corretamente estas variáveis.