### PR TITLE
Issue 477 - Corrigindo cssify 

### DIFF
--- a/src/cssify/README.md
+++ b/src/cssify/README.md
@@ -1,0 +1,55 @@
+cssify
+======
+
+Get your XPATHs translated to css automatically! (don't go to crazy on what you
+want to translate, this script is smart but won't do your breakfast).
+
+.. image:: https://travis-ci.org/santiycr/cssify.png?branch=master
+   :alt: [Build Status]
+   :target: https://travis-ci.org/santiycr/cssify
+
+.. image:: https://saucelabs.com/buildstatus/cssify
+   :alt: [Sauce Status]
+   :target: https://saucelabs.com/u/cssify
+
+Usage
+-----
+
+**New!** Use cssify from a browser::
+
+http://cssify.appspot.com
+
+Install::
+
+  $ pip install cssify
+
+From python::
+
+  $ pip install cssify
+  >>> from cssify import cssify
+  >>> cssify('//a')
+  'a'
+  >>> cssify('//a[@id="bleh"]')
+  'a#bleh'
+
+From the console::
+
+  $ ./cssify.py '//a'
+  a
+  $ ./cssify.py '//a[@id="bleh"]'
+  a#bleh
+
+Testing and contributing
+------------------------
+
+Supported and unsupported cases are documented by tests. If you have a request
+or a contribution for new conversions, include a test that proves the issue and
+solution and send a pull request.
+
+To run all unit tests locally::
+
+  $ nosetests tests/test_cssify.py
+
+To run all Selenium tests locally (some env variables are necessary)::
+
+  $ nosetests tests/test_cssify_web.py

--- a/src/cssify/cssify/__init__.py
+++ b/src/cssify/cssify/__init__.py
@@ -1,0 +1,1 @@
+from cssify.cssify import cssify

--- a/src/cssify/cssify/cssify.py
+++ b/src/cssify/cssify/cssify.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+
+import re
+import sys
+from optparse import OptionParser
+
+sub_regexes = {
+    "tag": "([a-zA-Z][a-zA-Z0-9]{0,10}|\*)",
+    "attribute": "[.a-zA-Z_:][-\w:.]*(\(\))?)",
+    "value": "\s*[\w/:][-/\w\s,:;.]*"
+}
+
+validation_re = (
+    "(?P<node>"
+      "("
+        "^id\([\"\']?(?P<idvalue>%(value)s)[\"\']?\)" # special case! id(idValue)
+      "|"
+        "(?P<nav>//?)(?P<tag>%(tag)s)" # //div
+        "(\[("
+          "(?P<matched>(?P<mattr>@?%(attribute)s=[\"\'](?P<mvalue>%(value)s))[\"\']" # [@id="bleh"] and [text()="meh"]
+        "|"
+          "(?P<contained>contains\((?P<cattr>@?%(attribute)s,\s*[\"\'](?P<cvalue>%(value)s)[\"\']\))" # [contains(text(), "bleh")] or [contains(@id, "bleh")]
+        ")\])?"
+        "(\[(?P<nth>\d+)\])?"
+      ")"
+    ")" % sub_regexes
+)
+
+prog = re.compile(validation_re)
+
+
+class XpathException(Exception):
+    pass
+
+
+def cssify(xpath):
+    """
+    Get your XPATHs translated to css automatically! (don't go to crazy on what
+    you want to translate, this script is smart but won't do your breakfast).
+    """
+
+    css = ""
+    position = 0
+
+    while position < len(xpath):
+        node = prog.match(xpath[position:])
+        if node is None:
+            raise XpathException("Invalid or unsupported Xpath: %s" % xpath)
+        log("node found: %s" % node)
+        match = node.groupdict()
+        log("broke node down to: %s" % match)
+
+        if position != 0:
+            nav = " " if match['nav'] == "//" else " > "
+        else:
+            nav = ""
+
+        tag = "" if match['tag'] == "*" else match['tag'] or ""
+
+        if match['idvalue']:
+            attr = "#%s" % match['idvalue'].replace(" ", "#")
+        elif match['matched']:
+            if match['mattr'] == "@id":
+                attr = "#%s" % match['mvalue'].replace(" ", "#")
+            elif match['mattr'] == "@class":
+                attr = ".%s" % match['mvalue'].replace(" ", ".")
+            elif match['mattr'] in ["text()", "."]:
+                attr = ":contains(^%s$)" % match['mvalue']
+            elif match['mattr']:
+                if match["mvalue"].find(" ") != -1:
+                    match["mvalue"] = "\"%s\"" % match["mvalue"]
+                attr = "[%s=%s]" % (match['mattr'].replace("@", ""),
+                                    match['mvalue'])
+        elif match['contained']:
+            if match['cattr'].startswith("@"):
+                attr = "[%s*=%s]" % (match['cattr'].replace("@", ""),
+                                     match['cvalue'])
+            elif match['cattr'] == "text()":
+                attr = ":contains(%s)" % match['cvalue']
+        else:
+            attr = ""
+
+        if match['nth']:
+            nth = ":nth-of-type(%s)" % match['nth']
+        else:
+            nth = ""
+
+        node_css = nav + tag + attr + nth
+
+        log("final node css: %s" % node_css)
+
+        css += node_css
+        position += node.end()
+    else:
+        css = css.strip()
+        return css
+
+if __name__ == "__main__":
+    usage = "usage: %prog [options] XPATH"
+    parser = OptionParser(usage)
+    parser.add_option("-v", "--verbose",
+                      action="store_true", dest="verbose", default=False,
+                      help="print status messages to stdout")
+
+    (options, args) = parser.parse_args()
+
+    if options.verbose:
+        def log(msg):
+            print("> %s" % msg)
+    else:
+        def log(msg):
+            pass
+
+    if len(args) != 1:
+        parser.error("incorrect number of arguments")
+    try:
+        print(cssify(args[0]))
+    except XpathException as e:
+        print(e)
+        sys.exit(1)
+else:
+    def log(msg):
+        pass

--- a/src/cssify/setup.py
+++ b/src/cssify/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name='cssify',
+    version='1.1',
+    description='Convert XPATH locators to CSS',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    license="MIT",
+    author='Santiago Suarez Ordonez',
+    author_email='santiycr@gmail.com',
+    packages=['cssify'],
+)
+

--- a/src/step-by-step/setup.py
+++ b/src/step-by-step/setup.py
@@ -14,5 +14,5 @@ setup(
     author='Tales Panoutsos',
     author_email='TalesPanoutsos@users.noreply.github.com',
     packages=['step_crawler'],
-    install_requires=['cssify', 'selenium', 'asyncio', 'pyppeteer2', 'pyext', 'pillow']
+    install_requires=['selenium', 'asyncio', 'pyppeteer2', 'pyext', 'pillow']
 )


### PR DESCRIPTION
Para corrigir o erro na tradução de XPaths com posições com mais de um dígito (ex: //*[@id='paginacao']/li[10]/a), substituimos o módulo cssify por uma versão local, com a correção do regex.
Na verdade, no repositório do módulo este erro já foi corrigido em 2020, porém, a versão do pypi não foi atualizada até o momento.

Closes #477 