### PR TITLE
Issue #495 - Diminuir listagem de instâncias de execução

### DIFF
--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -237,3 +237,19 @@ a.close, a.add_form {
 }
 /* End collapse div */
 
+/* Hide instances from large list */
+.multinstancias.hidden {
+    display: none;
+}
+#show_hide_instances::before {
+    content: "<";
+    transform: rotate(90deg);
+    display: inline-block;
+}
+#show_hide_instances.hidden::before {
+    transform: rotate(-90deg);
+}
+#show_hide_instances.focus, #show_hide_instances:focus {
+    text-decoration: none;
+}
+/* End hide instances from large list */

--- a/main/staticfiles/js/details.js
+++ b/main/staticfiles/js/details.js
@@ -17,6 +17,13 @@ document.addEventListener('DOMContentLoaded',
     false
 );
 
+function show_hide_instances(){
+    var instances_lines = Array.prototype.slice.apply(document.querySelectorAll(".multinstancias"));
+    instances_lines.forEach((instance) => {
+        instance.classList.toggle("hidden");
+    });
+}
+
 
 function tail_logs(instance_id){
     // calls tail log view and set logs
@@ -100,3 +107,5 @@ function status_f_instance(instance_id){
         500
     ); 
 }
+
+

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -65,13 +65,16 @@ Crawler "{{ crawler.source_name }}"
                 </thead>
                 <tbody>
                     {% for instance in instances %}
-                    <tr>                        
+                    <tr {% if forloop.counter > 3 %} class="multinstancias hidden" {% endif %}>                        
                         <td>{{instance.instance_id}}</td>
                         <td>{{instance.creation_date}}</td>
                         <td>{{instance.last_modified}}</td>
                         <td><button type="button" class="btn btn-primary">Abrir</button></td>
                         <td><button type="button" class="btn btn-primary">Abrir</button></td>
                     </tr>
+                    {% if forloop.last and forloop.counter > 3 %}
+                        <tr><td colspan="5"><button onclick="show_hide_instances(); this.classList.toggle('hidden');" type="button" id="show_hide_instances" class="btn btn-link hidden"> Mostrar todos ({{forloop.counter}})</button></td></tr>
+                    {% endif %}
                     {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
Na página de detalhes do coletor, só mostra as últimas 3 instâncias executadas e esconde o resto. Tendo o botão "Mostrar todos" que libera a listagem completa.

Closes #495 