### PR TITLE
Issue 552 - Remove importação da biblioteca pandas

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -12,7 +12,6 @@ import itertools
 import logging
 import os
 import re
-import pandas
 import time
 from lxml.html.clean import Cleaner
 import urllib.parse as urlparse


### PR DESCRIPTION
A biblioteca pandas é importada no arquivo `base_spider.py` e não é utilizada. Essa importação faz com que as coletas não funcionem ao instalar o sistema em um ambiente Python limpo. Os módulos de extração instalavam essa biblioteca anteriormente, por isso instalações antigas funcionam normalmente.

Closes #552.