### PR TITLE
Issue 528 - Seleção de formulários durante detecção

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -396,6 +396,7 @@ class ParameterHandlerForm(forms.ModelForm):
 
         self.fields['parameter_type'] = forms.ChoiceField(
             choices=choices,
+            label='Tipo de parâmetro',
             widget=forms.Select(attrs={
                 'onchange': 'detailParamType(event);'
             })
@@ -463,7 +464,6 @@ class ParameterHandlerForm(forms.ModelForm):
         model = ParameterHandler
         fields = '__all__'
         labels = {
-            'parameter_type': 'Tipo de parâmetro',
             'first_num_param': 'Primeiro valor a gerar',
             'last_num_param': 'Último valor a gerar',
             'leading_num_param': 'Zeros à esquerda',

--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -253,3 +253,18 @@ a.close, a.add_form {
     text-decoration: none;
 }
 /* End hide instances from large list */
+
+/* Modal styles */
+.modal-backdrop {
+    opacity:0.5;
+}
+.form_detection_el {
+    margin-left: 1em;
+}
+.form_indented {
+    margin-left: 2em;
+}
+.form_field_label {
+    margin-left: 0.25em;
+}
+/* End modal styles */

--- a/main/templates/main/injection_config.html
+++ b/main/templates/main/injection_config.html
@@ -22,6 +22,41 @@
     </div>
 {% endwith %}
 
+<!-- Form selection modal -->
+{% if injection_type == "static_form" %}
+<div class="modal" id="form_detection_modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Seleção de formulários</h5>
+                <button type="button" class="close" data-dismiss="modal"
+                    aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+                </div>
+                <div class="modal-body row">
+                    <div class="text-center col">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Carregando...</span>
+                        </div>
+                    </div>
+                    <div class="form_list">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                <button type="button" class="btn btn-primary include_fields">
+                    Incluir campos
+                </button>
+                <button type="button" class="btn btn-secondary"
+                    data-dismiss="modal">
+                    Fechar
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Response handling-->
 <div id="{{ injection_type }}_response">
     {{ response_formset.management_form }}

--- a/main/views.py
+++ b/main/views.py
@@ -374,13 +374,25 @@ def load_form_fields(request):
             parser = None
 
             try:
-                forms = HTMLExtractor(url=curr_url).get_forms()
+                extractor = HTMLExtractor(url=curr_url)
             except MissingSchema as e:
                 # URL schema error
                 return JsonResponse({
                     'error': 'URL inválida, o protocolo foi especificado? ' +
                              '(ex: http://, https://)'
                 }, status=404)
+
+            if not extractor.html_response.ok:
+                # Error during form extractor request
+                status_code = extractor.html_response.status_code
+                return JsonResponse({
+                    'error': 'Erro ao acessar a página (HTTP ' +
+                        str(status_code) + '). Verifique se a URL inicial ' +
+                        'está correta e se a página de interesse está ' +
+                        'funcionando.'
+                }, status=404)
+
+            forms = extractor.get_forms()
 
             if len(forms) == 0:
                 # Failed to find a form in a valid page

--- a/src/form_parser/formparser/html/parser.py
+++ b/src/form_parser/formparser/html/parser.py
@@ -94,7 +94,17 @@ class Parser:
         Returns:
             List of field labels
         """
-        return [label.text for label in self.form.xpath(".//label")]
+
+        labels = [label.text for label in self.form.xpath(".//label")]
+
+        # Supply an empty label for hidden fields (this usually aligns labels
+        # properly)
+        types = self.list_input_types()
+        for i, t in enumerate(types):
+            if t == "hidden":
+                labels.insert(i, "")
+
+        return labels
 
     def required_fields(self, probing_element=None, submit_button_xpath=None,
                         form_url=None, fillers=None, include_hidden=False,


### PR DESCRIPTION
Ao usar o detector de formulários, agora é possível selecionar entre os diferentes formulários encontrados em uma página, e filtrar os campos de interesse. Ao selecionar um formulário, os campos dos outros formulários são desabilitados e os campos do formulário selecionado são marcados para inserção. O usuário pode ainda selecionar quais campos específicos deseja injetar. Caso a página não contenha formulários, ou ocorra algum erro na detecção ou no uso de URLs parametrizadas, o usuário é informado.

A seguinte URL pode ser usada para testes: https://transparencia.mg.gov.br/estado-pessoal/viagens. Obviamente outros exemplos também são bem vindos, para testar a robustez do mecanismo.