### PR TITLE
Issue 627 - Corrige bug de codificação de páginas coletadas

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -27,7 +27,7 @@ from crawlers.file_descriptor import FileDescriptor
 from crawlers.injector_tools import create_probing_object,\
     create_parameter_generators
 
-from main.models import HEADER_ENCODE_DETECTION, AUTO_ENCODE_DETECTION
+from main.models import CrawlRequest
 from crawlers.constants import AUTO_ENCODE_DETECTION_CONFIDENCE_THRESHOLD
 
 PUNCTUATIONS = "[{}]".format(string.punctuation)
@@ -212,14 +212,14 @@ class BaseSpider(scrapy.Spider):
 
         encoding = None
         encoding_detection_method = self.config.get(
-            'encoding_detection_method', HEADER_ENCODE_DETECTION)
+            'encoding_detection_method', CrawlRequest.HEADER_ENCODE_DETECTION)
 
-        if encoding_detection_method == HEADER_ENCODE_DETECTION:
+        if encoding_detection_method == CrawlRequest.HEADER_ENCODE_DETECTION:
             content_type = response.headers['Content-type'].decode()
             _, params = cgi.parse_header(content_type)
             encoding = params['charset']
 
-        elif encoding_detection_method == AUTO_ENCODE_DETECTION:
+        elif encoding_detection_method == CrawlRequest.AUTO_ENCODE_DETECTION:
             detection = chardet.detect(response.body)
 
             detected_encoding = detection['encoding']

--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -1,5 +1,4 @@
 # Scrapy and Twister libs
-from io import RawIOBase
 import scrapy
 from scrapy.exceptions import CloseSpider
 from scrapy.spidermiddlewares.httperror import HttpError

--- a/crawlers/constants.py
+++ b/crawlers/constants.py
@@ -1,2 +1,5 @@
 # CURR_FOLDER_FROM_ROOT = "main/src"
 CURR_FOLDER_FROM_ROOT = "crawlers"
+
+# Encoding detection will only be considered valid above this threshold
+AUTO_ENCODE_DETECTION_CONFIDENCE_THRESHOLD = .8

--- a/main/forms.py
+++ b/main/forms.py
@@ -1,9 +1,6 @@
 from django import forms
-from .models import CrawlRequest, ParameterHandler, ResponseHandler
+from .models import CrawlRequest, ParameterHandler, ResponseHandler, ENCODE_DETECTION_CHOICES, HEADER_ENCODE_DETECTION
 from django.core.exceptions import ValidationError
-from django.core.validators import RegexValidator
-
-import re
 
 
 class CrawlRequestForm(forms.ModelForm):
@@ -64,6 +61,8 @@ class CrawlRequestForm(forms.ModelForm):
             'download_imgs',
             'steps',
             'data_path',
+
+            'encoding_detection_method'
         ]
 
 class RawCrawlRequestForm(CrawlRequestForm):
@@ -348,6 +347,12 @@ class RawCrawlRequestForm(CrawlRequestForm):
 
     # Crawler Type - Single file
     # Crawler Type - Bundle file
+
+    # ENCODE DETECTION METHOD
+    encoding_detection_method = forms.ChoiceField(choices=ENCODE_DETECTION_CHOICES, 
+                                                    label='Método de detecção de codificação das páginas',
+                                                    initial=HEADER_ENCODE_DETECTION,
+                                                    widget=forms.RadioSelect)
 
 class ResponseHandlerForm(forms.ModelForm):
     """

--- a/main/forms.py
+++ b/main/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import CrawlRequest, ParameterHandler, ResponseHandler, ENCODE_DETECTION_CHOICES, HEADER_ENCODE_DETECTION
+from .models import CrawlRequest, ParameterHandler, ResponseHandler
 from django.core.exceptions import ValidationError
 
 
@@ -349,9 +349,9 @@ class RawCrawlRequestForm(CrawlRequestForm):
     # Crawler Type - Bundle file
 
     # ENCODE DETECTION METHOD
-    encoding_detection_method = forms.ChoiceField(choices=ENCODE_DETECTION_CHOICES, 
+    encoding_detection_method = forms.ChoiceField(choices=CrawlRequest.ENCODE_DETECTION_CHOICES, 
                                                     label='Método de detecção de codificação das páginas',
-                                                    initial=HEADER_ENCODE_DETECTION,
+                                                    initial=CrawlRequest.HEADER_ENCODE_DETECTION,
                                                     widget=forms.RadioSelect)
 
 class ResponseHandlerForm(forms.ModelForm):

--- a/main/models.py
+++ b/main/models.py
@@ -4,14 +4,6 @@ from django.core.validators import RegexValidator
 
 from crawlers.constants import *
 
-HEADER_ENCODE_DETECTION = 1
-AUTO_ENCODE_DETECTION = 2
-
-ENCODE_DETECTION_CHOICES = [
-    (HEADER_ENCODE_DETECTION, 'Via cabeçalho da resposta'),
-    (AUTO_ENCODE_DETECTION, 'Automático'),
-]
-
 class TimeStamped(models.Model):
     creation_date = models.DateTimeField()
     last_modified = models.DateTimeField()
@@ -159,6 +151,15 @@ class CrawlRequest(TimeStamped):
     steps = models.CharField(
         blank=True, null=True, max_length=9999999, default='{}')
     
+    # ENCODING DETECTION ======================================================= 
+    HEADER_ENCODE_DETECTION = 1
+    AUTO_ENCODE_DETECTION = 2
+
+    ENCODE_DETECTION_CHOICES = [
+        (HEADER_ENCODE_DETECTION, 'Via cabeçalho da resposta'),
+        (AUTO_ENCODE_DETECTION, 'Automático'),
+    ]
+
     encoding_detection_method = models.IntegerField(choices=ENCODE_DETECTION_CHOICES, default=HEADER_ENCODE_DETECTION)
 
     @staticmethod

--- a/main/models.py
+++ b/main/models.py
@@ -4,6 +4,13 @@ from django.core.validators import RegexValidator
 
 from crawlers.constants import *
 
+HEADER_ENCODE_DETECTION = 1
+AUTO_ENCODE_DETECTION = 2
+
+ENCODE_DETECTION_CHOICES = [
+    (HEADER_ENCODE_DETECTION, 'Via cabeçalho da resposta'),
+    (AUTO_ENCODE_DETECTION, 'Automático'),
+]
 
 class TimeStamped(models.Model):
     creation_date = models.DateTimeField()
@@ -151,6 +158,8 @@ class CrawlRequest(TimeStamped):
 
     steps = models.CharField(
         blank=True, null=True, max_length=9999999, default='{}')
+    
+    encoding_detection_method = models.IntegerField(choices=ENCODE_DETECTION_CHOICES, default=HEADER_ENCODE_DETECTION)
 
     @staticmethod
     def process_parameter_data(param_list):

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -315,11 +315,18 @@ New Crawler
                                         </div>
                                         <div class="mycollapse" id="adv-links">
                                             <div class="mycollapse-block  p-4 pb-0 rounded mt-3">
+                                                {{ form.encoding_detection_method | as_crispy_field }}
+                                                <p class="small">Essa configuração permite escolher como será obtido a codificação para salvamento das páginas salvas. 
+                                                    O padrão é via cabeçalho das respostas do servidor, que devem funcionar para a maiorias dos casos e é mais rápido. 
+                                                    O método automático tentará detectar a codificação automaticamente, o que é mais lento mas pode resolver caso de 
+                                                    respostas incorretas do servidor. A detecção de codificação não é perfeita, portanto, o nível de confidência de <strong>85%</strong> é adotado.
+                                                </p>
+
                                                 {{ form.link_extractor_allow_domains | as_crispy_field }}
                                                 {{ form.link_extractor_tags | as_crispy_field }}
                                                 {{ form.link_extractor_attrs | as_crispy_field }}
                                                 {{ form.link_extractor_check_type | as_crispy_field }}
-                                                <p>Se existirem urls que apontam para arquivos mas não <strong>terminam</strong>
+                                                <p class="small">Se existirem urls que apontam para arquivos mas não <strong>terminam</strong>
                                                     em uma extensão de arquivo, o coletor pode conferir o tipo da página pra qual a url aponta.
                                                     Nesse caso, ele irá requisitar os <i>headers</i> da url. Se o tipo for <i>'text/html'</i>,
                                                     a página será tratada com um html; caso contrário, como um arquivo. Habilitar essa opção
@@ -355,10 +362,10 @@ New Crawler
                                         {{ form.download_files_check_large_content | as_crispy_field}}
 
                                         <p class="small">Caso não haja arquivos grandes (>1GB) a serem coletados, desabilite a opção acima para ganhar desempenho. </p>
-                                    <div id="dynamic_processing" class="">
+                                    </div>
+                                    <div id="dynamic_processing" class="" style="padding: 0 20px 0 20px;">
                                         {{ form.dynamic_processing | as_crispy_field}}
                                     </div>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -316,10 +316,10 @@ New Crawler
                                         <div class="mycollapse" id="adv-links">
                                             <div class="mycollapse-block  p-4 pb-0 rounded mt-3">
                                                 {{ form.encoding_detection_method | as_crispy_field }}
-                                                <p class="small">Essa configuração permite escolher como será obtido a codificação para salvamento das páginas salvas. 
+                                                <p class="small">Essa configuração permite escolher como será obtida a codificação para salvamento das páginas salvas. 
                                                     O padrão é via cabeçalho das respostas do servidor, que devem funcionar para a maiorias dos casos e é mais rápido. 
                                                     O método automático tentará detectar a codificação automaticamente, o que é mais lento mas pode resolver caso de 
-                                                    respostas incorretas do servidor. A detecção de codificação não é perfeita, portanto, o nível de confidência de <strong>85%</strong> é adotado.
+                                                    respostas incorretas do servidor. A detecção de codificação não é perfeita, portanto, o nível de confiança de <strong>80%</strong> é adotado.
                                                 </p>
 
                                                 {{ form.link_extractor_allow_domains | as_crispy_field }}

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -330,6 +330,9 @@ New Crawler
                                                     O padrão é via cabeçalho das respostas do servidor, que devem funcionar para a maiorias dos casos e é mais rápido. 
                                                     O método automático tentará detectar a codificação automaticamente, o que é mais lento mas pode resolver caso de 
                                                     respostas incorretas do servidor. A detecção de codificação não é perfeita, portanto, o nível de confiança de <strong>80%</strong> é adotado.
+                                                    <br>
+                                                    <br>
+                                                    <strong>Obs.:</strong>A detecção automática de codificação não é atualmente suportada em páginas dinâmicas.
                                                 </p>
 
                                                 {{ form.link_extractor_allow_domains | as_crispy_field }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest
 pytest-mock
 python3-wget
 validators
+cchardet==2.1.7

--- a/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
+++ b/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
@@ -209,14 +209,14 @@ class PuppeteerMiddleware:
             steps = code_g.generate_code(request.steps, functions_file)
             request.meta["pages"] = await steps.execute_steps(page=page)
 
-        content = await page.content()
-        body = str.encode(content)
-
-        await page.close()
-
         content_type = response.headers['content-type']
         _, params = cgi.parse_header(content_type)
         encoding = params['charset']
+
+        content = await page.content()
+        body = str.encode(content, encoding=encoding, errors='ignore')
+
+        await page.close()
 
         # Necessary to bypass the compression middleware (?)
         response.headers.pop('content-encoding', None)

--- a/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
+++ b/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
@@ -15,7 +15,7 @@ try:
 except Exception:
     pass
 
-  import cgi
+import cgi
 
 import base64
 import datetime

--- a/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
+++ b/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
@@ -12,11 +12,7 @@ try:
     asyncioreactor.install(loop)
 except Exception:
     pass
-import logging
-import requests
-import sys
-import os
-import time
+import cgi
 
 from step_crawler import code_generator as code_g
 from step_crawler import functions_file
@@ -172,6 +168,10 @@ class PuppeteerMiddleware:
 
         await page.close()
 
+        content_type = response.headers['content-type']
+        _, params = cgi.parse_header(content_type)
+        encoding = params['charset']
+
         # Necessary to bypass the compression middleware (?)
         response.headers.pop('content-encoding', None)
         response.headers.pop('Content-Encoding', None)
@@ -181,7 +181,7 @@ class PuppeteerMiddleware:
             status=response.status,
             headers=response.headers,
             body=body,
-            encoding='utf-8',
+            encoding=encoding,
             request=request
         )
 

--- a/tests/test_scrapy_puppeteer/test_middlewares.py
+++ b/tests/test_scrapy_puppeteer/test_middlewares.py
@@ -49,6 +49,10 @@ class ScrapyPuppeteerTestCase(unittest.TestCase):
 
         # Response mock
         mockResponse = mock.create_autospec(pyppeteer.network_manager.Response)
+        mockResponse.headers = {
+            'content-type': 'text/html; charset=iso-8859-1'
+        }
+
         self.mockResponse = mockResponse
 
         # Page mock


### PR DESCRIPTION
Antes, as páginas coletadas eram salvas sempre com codificação `UTF-8`, porém, isso trouxe problemas em certas coletas com outras codificações, como apontado em #627. 

Agora, as páginas coletadas são salvas segundo a codificação do cabeçalho indicado pela resposta do servidor. Foi adicionado um novo campo na descrição das páginas coletadas (`encoding`), com a codificação usada para salvar o arquivo.