### PR TITLE
Issue 679 - Suporte para XPaths mais complexos no passo de clique

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -40,7 +40,11 @@ async def wait_page(page):
 async def clique(page, param):
     if type(param) == str:
         await page.waitForXPath(param)
-        await page.click(cssify(param))
+        elements = await page.xpath(param)
+        if len(elements) == 1:
+            await elements[0].click()
+        else:
+            raise Exception('XPath points to non existent element, or multiple elements!')
     else:
         param.click()
     await wait_page(page)


### PR DESCRIPTION
Antes a função de clique no mecanismo de passos utilizava a biblioteca cssify para converter o XPath para CSS, e este seria utilizado para clicar no elemento utilizando o pyppeteer, o que limitava a utillização de XPaths não suportados pelo cssify. 

Agora, com o próprio pyppeteer processando o XPath, é possível utilizar predicados [novos](https://www.w3schools.com/xml/xpath_syntax.asp), como last(), position(), entre outros, no interior dos XPaths passados para a função de clique.