### PR TITLE
Issue 692 - Corrige requerimentos do módulo 'crawling_utils'

### DIFF
--- a/src/crawling_utils/setup.py
+++ b/src/crawling_utils/setup.py
@@ -9,5 +9,5 @@ setup(
     author='Gabriel Cardoso',
     author_email='gabrielcrds@users.noreply.github.com',
     packages=['crawling_utils'],
-    install_requires=['selenium']
+    install_requires=['selenium', 'requests']
 )


### PR DESCRIPTION
O módulo `crawling_utils` necessita da biblioteca `requests`, que não estava incluída em seu arquivo `setup.py`. Essa PR inclui essa mudança.

Closes #692.