### PR TITLE
Issue 446 - usabilidade e funcionamento da interface de passos

### DIFF
--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -164,6 +164,11 @@ table.dataTable thead .sorting_desc_disabled:before {
 
 /* Step styles -----------*/
 
+#dynamic-processing-item-wrap.disabled {
+    opacity: .5;
+    pointer-events: none;
+}
+
 .step-block {
     margin-top: 0em;
 }

--- a/main/staticfiles/js/create_crawler.js
+++ b/main/staticfiles/js/create_crawler.js
@@ -447,10 +447,13 @@ function detailWebdriverType() {
 }
 
 function detailDynamicProcessing() {
-    dynamic_processing_block = document.getElementById("dynamic-processing-item")
+    dynamic_processing_check = document.getElementById("dynamic-processing-valid-icon")
+    dynamic_processing_block = document.getElementById("dynamic-processing-item-wrap")
     if(getCheckboxState("id_dynamic_processing")){
+        dynamic_processing_check.classList.remove("disabled")
         dynamic_processing_block.classList.remove("disabled")
     }else{
+        dynamic_processing_check.classList.add("disabled")
         dynamic_processing_block.classList.add("disabled")
     }
 }

--- a/main/staticfiles/js/steps.js
+++ b/main/staticfiles/js/steps.js
@@ -58,16 +58,14 @@ function init_steps_creation_interface(interface_root_element, output_element, s
     add_block_button.onclick = function(){step_board.add_block(step_list)}
     add_block_button.innerText = "Add step"
 
-
-    save_button = document.createElement("button")
-    save_button.innerText = "Save steps"
-    save_button.className="btn btn-primary step-controler-buttons"
-    save_button.style.color = "white"
-    interface_root_element.save_button = save_button
-    interface_root_element.save_button.onclick = function(){build_json(step_board, output_element)}
+    interface_root_element.save_button = document.getElementById('createButton')
+    interface_root_element.save_button.onmousedown = function(){
+        if(getCheckboxState("id_dynamic_processing") && step_board.children.length > 0){            
+            build_json(step_board, output_element)
+        }
+    }
 
     step_controler.appendChild(add_block_button)
-    step_controler.appendChild(save_button)
     steps_creation_interface.appendChild(step_controler)
     steps_creation_interface.appendChild(step_board)
     steps_creation_interface.step_controler = step_controler

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -118,19 +118,6 @@ New Crawler
                 </li>
 
                 <!-- /END Separator -->
-                <a onClick="showBlock(this.id)" href="#"
-                    class="button-block bg-dark list-group-item list-group-item-action" id="crawler-details-item">
-                    <div class="d-flex w-100 justify-content-start align-items-center">
-                        <div class="col-md-10 sidemenu-items">
-                            <span class="fa fa-gear fa-fw mr-3"></span>
-                            <span class="menu-collapsed">Detalhes do coletor</span>
-                        </div>
-                        <div class="col-md-2">
-                            <span id="crawler-details-valid-icon"
-                                class="fa fa-check fa-fw mr-3 crawler-details-valid-icon valid-icon"></span>
-                        </div>
-                    </div>
-                </a>
 
                 <!-- implementation local begin -->
                 <a onClick="showBlock(this.id); load_steps_interface(this.id + '-block', 'id_steps');" href="#"
@@ -148,6 +135,19 @@ New Crawler
                 </a>
                 <!-- implementation local end -->
 
+                <a onClick="showBlock(this.id)" href="#"
+                    class="button-block bg-dark list-group-item list-group-item-action" id="crawler-details-item">
+                    <div class="d-flex w-100 justify-content-start align-items-center">
+                        <div class="col-md-10 sidemenu-items">
+                            <span class="fa fa-gear fa-fw mr-3"></span>
+                            <span class="menu-collapsed">Detalhes do coletor</span>
+                        </div>
+                        <div class="col-md-2">
+                            <span id="crawler-details-valid-icon"
+                                class="fa fa-check fa-fw mr-3 crawler-details-valid-icon valid-icon"></span>
+                        </div>
+                    </div>
+                </a>
 
                 <a href="#" class="disabled bg-dark list-group-item list-group-item-action">
                     <div class="d-flex w-100 justify-content-start align-items-center">

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -120,16 +120,16 @@ New Crawler
                 <!-- /END Separator -->
 
                 <!-- implementation local begin -->
-                <a onClick="showBlock(this.id); load_steps_interface(this.id + '-block', 'id_steps');" href="#"
-                    class="disabled button-block bg-dark list-group-item list-group-item-action" id="dynamic-processing-item">
+                <a onClick="showBlock(this.id); load_steps_interface(this.id + '-wrap', 'id_steps');" href="#"
+                    class="button-block bg-dark list-group-item list-group-item-action" id="dynamic-processing-item">
                     <div class="d-flex w-100 justify-content-start align-items-center">
                         <div class="col-md-10 sidemenu-items">
                             <span class="fa fa-code fa-fw mr-3"></span>
                             <span class="menu-collapsed">Processamento dinâmico</span>
                         </div>
                         <div class="col-md-2">
-                            <span id="crawler-details-valid-icon"
-                                class="fa fa-check fa-fw mr-3 crawler-details-valid-icon valid-icon"></span>
+                            <span id="dynamic-processing-valid-icon"
+                                class="fa fa-check fa-fw mr-3 crawler-details-valid-icon valid-icon disabled"></span>
                         </div>
                     </div>
                 </a>
@@ -301,6 +301,16 @@ New Crawler
                         </div>
                     </div>
 
+
+                    <div id="dynamic-processing-item-block" class="block" hidden>
+                        <div id="dynamic_processing" class="">
+                            {{ form.dynamic_processing | as_crispy_field}}
+                        </div>
+                        <div id="dynamic-processing-item-wrap" class="" style="padding:20px;" class="hidden">
+                            {{ form.steps | as_crispy_field }}
+                        </div>
+                    </div>
+
                     <div id="crawler-details-item-block" class="block" hidden>
                         <div class="row">
                             <div class="col md-6">
@@ -355,17 +365,10 @@ New Crawler
                                         {{ form.download_files_check_large_content | as_crispy_field}}
 
                                         <p class="small">Caso não haja arquivos grandes (>1GB) a serem coletados, desabilite a opção acima para ganhar desempenho. </p>
-                                    <div id="dynamic_processing" class="">
-                                        {{ form.dynamic_processing | as_crispy_field}}
-                                    </div>
+                            
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </div>
-                <div id="dynamic-processing-item-block" class="block" hidden>
-                    <div class="row" style="padding:20px;">
-                        {{ form.steps | as_crispy_field }}
                     </div>
                 </div>
 


### PR DESCRIPTION
Troquei a ordem do menu, colocando o Processamento dinâmico antes dos Detalhes do coletor, pra ficar de acordo com a ordem de execução, e passei o checkbox de habilitar os passos pra dentro da sessão correspondente. Também ajustando a indicação visual do uso do processamento dinâmico no menu.

Removi o botão Save Steps, passando a ação de gerar o JSON de passos pro botão de Create/Update do coletor. Verificando se o processamento dinâmico esta ativo e se tem pelo menos um passo configurado, assim, não apaga um json gerado anteriormente. Isto pode ser modificado quando o loading de passos (#281) for finalizado.


