### PR TITLE
Issue 704 -  Erro na inferência de limites de busca

### DIFF
--- a/src/range_inference/range_inference/range_inference.py
+++ b/src/range_inference/range_inference/range_inference.py
@@ -142,7 +142,7 @@ class RangeInference():
         param_index = extra_params.index(None)
 
         params_instance = extra_params.copy()
-        while curr_begin < curr_end:
+        while curr_begin <= curr_end:
             mid = mid_calc(curr_begin, curr_end)
             # check the required number of entries before declaring a miss
             all_miss = True

--- a/tests/test_range_inference/test_range_inference.py
+++ b/tests/test_range_inference/test_range_inference.py
@@ -94,6 +94,18 @@ class RangeInferenceTest(unittest.TestCase):
                                                          cons_misses=10)
         self.assertEqual(last_entry, 50)
 
+        # Last entry at end of search space
+        entry_probe = RangeInferenceTest.dummy_entry_probe(0, 50)
+        last_entry = RangeInference.filter_numeric_range(0, 50, entry_probe,
+                                                         cons_misses=1)
+        self.assertEqual(last_entry, 50)
+
+        # Last entry at end of search space (with smaller search space)
+        entry_probe = RangeInferenceTest.dummy_entry_probe(1, 2)
+        last_entry = RangeInference.filter_numeric_range(1, 2, entry_probe,
+                                                         cons_misses=1)
+        self.assertEqual(last_entry, 2)
+
         # Interval beginning at 25 and ending at 48
         entry_probe = RangeInferenceTest.dummy_entry_probe(25, 48)
         last_entry = RangeInference.filter_numeric_range(0, 200, entry_probe,


### PR DESCRIPTION
Corrige um pequeno bug no inferidor de limites de parâmetros: em casos onde todos os valores a buscar são válidos podemos ter um problema onde o penúltimo valor do intervalo é retornado, e não o último. O bug foi resolvido, e dois testes foram adicionados para esse caso.

Um caso de uso para teste desse bug foi fornecido na descrição da issue referente a essa PR.

Closes #704.