### PR TITLE
Issue 699 - Adição da função 'Extrair Texto' no mecanismo de passos

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -63,6 +63,11 @@ async def salva_pagina(page):
     body = str.encode(content)
     return body
 
+@step
+async def extrai_texto(page, xpath):
+    await page.waitForXPath(xpath)
+    text = await page.Jeval(cssify(xpath), "el => el.textContent")
+    return text
 
 @step
 async def opcoes(page, xpath, exceto=None):


### PR DESCRIPTION
Adiciona uma função que o extrai texto de elementos html na página sendo coletada. Mais exatamente, a função busca a tag apontada pelo xpath, e extrai o texto que se encontra no interior da tag.

Esta função sozinha ainda não pode ser usada de forma útil na interface, visto que não há como atribuir o resultado da função a uma variável, por exemplo (#698). Mas como teste, pode se usar ela no interior de um para cada, junto com a função de impressão para verificar o resultado.