### PR TITLE
[ISSUE-714] - Correção de reescrita de download de arquivos de mesmo nome

### DIFF
--- a/src/scrapy_puppeteer/setup.py
+++ b/src/scrapy_puppeteer/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     author_email='rennanl@ufmg.br',
     packages=setuptools.find_packages(),
     install_requires=['scrapy>=1.0.0', 'promise', 'pyppeteer2',
-                     'requests', 'twisted'],
+                     'requests', 'twisted', 'filetype==1.0.7'],
     entry_points={
         'console_scripts': [
             'scrapyp = scrapy_puppeteer.cli:__main__',


### PR DESCRIPTION
Os nomes dos arquivos agora seguem um padrão aleatório. Nesse processo, a extensão deles é perdida. Assim, foi necessário inferir o tipo do arquivo por meio de seu "número mágico", por meio da biblioteca [filetype](https://pypi.org/project/filetype/).