### PR TITLE
Issue 700 - Adiciona o passo 'Abrir em Nova aba' e 'Fechar Aba'

### DIFF
--- a/main/staticfiles/js/step_block.js
+++ b/main/staticfiles/js/step_block.js
@@ -58,6 +58,7 @@ function init_block(step_list, depth){
     //Setting the estrutural steps builders
     block.turn_to_for_step = turn_to_for_step
     block.turn_to_pagination_step = turn_to_pagination_step
+    block.turn_to_new_tab_step = turn_to_new_tab_step
 
     //Setting the border functions
     block.onmouseout = function(){
@@ -317,6 +318,8 @@ function refresh_step(){
 
     if(this.value=="para cada"){
         block.turn_to_for_step()
+    }else if(this.value=="abrir em nova aba"){
+        block.turn_to_new_tab_step()
     }else if(this.value=="for each page in"){
         block.turn_to_pagination_step()
     }else{
@@ -392,6 +395,28 @@ function turn_to_pagination_step(){
     block.add_param("buttons ambiguous xpath")
     block.step.optional_params = {"next button index":-1}
     block.init_optional_params_button()
+}
+
+/**
+ * Sets the block to the open in new page step.
+ * This function is a method of the block.
+ */
+function turn_to_new_tab_step(){
+    block = find_parent_with_attr_worth(this, "block")
+    block.delete_lines(block.lines.length)
+    block.add_line()
+
+    // defines link xpath
+    xpath_input_box = document.createElement("DIV")
+    xpath_input_box.className = "col-sm"    
+    xpath_input = document.createElement("INPUT")
+    xpath_input.placeHolder = "link xpath"
+    xpath_input.className = "form-control row"
+    xpath_input_box.appendChild(xpath_input)
+    block.xpath_input = xpath_input
+
+    block.lines[0].row.appendChild(xpath_input_box)
+    block.lines[0].row.full = true
 }
 
 

--- a/main/staticfiles/js/step_block.js
+++ b/main/staticfiles/js/step_block.js
@@ -59,6 +59,7 @@ function init_block(step_list, depth){
     block.turn_to_for_step = turn_to_for_step
     block.turn_to_pagination_step = turn_to_pagination_step
     block.turn_to_new_tab_step = turn_to_new_tab_step
+    block.turn_to_close_tab_step = turn_to_close_tab_step
 
     //Setting the border functions
     block.onmouseout = function(){
@@ -320,6 +321,8 @@ function refresh_step(){
         block.turn_to_for_step()
     }else if(this.value=="abrir em nova aba"){
         block.turn_to_new_tab_step()
+    }else if(this.value=="fechar aba"){
+        block.turn_to_close_tab_step()
     }else if(this.value=="for each page in"){
         block.turn_to_pagination_step()
     }else{
@@ -416,6 +419,13 @@ function turn_to_new_tab_step(){
     block.xpath_input = xpath_input
 
     block.lines[0].row.appendChild(xpath_input_box)
+    block.lines[0].row.full = true
+}
+
+function turn_to_close_tab_step(){
+    block = find_parent_with_attr_worth(this, "block")
+    block.delete_lines(block.lines.length)
+    block.add_line()
     block.lines[0].row.full = true
 }
 

--- a/main/staticfiles/js/steps.js
+++ b/main/staticfiles/js/steps.js
@@ -23,6 +23,7 @@ function load_steps_interface(interface_root_element_id, output_element_id, json
         step_list = step_list.concat(JSON.parse('{"name":"object", "mandatory_params":["ex: [1,2,3]"], "optional_params":{}}'))
         step_list = step_list.concat(JSON.parse('{"name":"para cada", "mandatory_params":[], "optional_params":{}}'))
         step_list = step_list.concat(JSON.parse('{"name":"for each page in", "mandatory_params":[], "optional_params":{}}'))
+        step_list = step_list.concat(JSON.parse('{"name":"abrir em nova aba", "mandatory_params":[], "optional_params":{}}'))
         init_steps_creation_interface(interface_root_element, output_element, step_list)
       }
     };
@@ -196,6 +197,9 @@ function get_step_json_format(block){
         for(param of block.params){
             step_dict.iterable.call.arguments[param.children[0].placeholder.replace(/ /g, "_")] = param.children[0].value
         }
+    }else if(param_name == "abrir_em_nova_aba"){
+        step_dict.link_xpath = block.xpath_input.value
+        step_dict.children = []
     }else if(param_name == "for_each_page_in"){
         step_dict.children = []
         for(param of block.params){

--- a/main/staticfiles/js/steps.js
+++ b/main/staticfiles/js/steps.js
@@ -24,6 +24,7 @@ function load_steps_interface(interface_root_element_id, output_element_id, json
         step_list = step_list.concat(JSON.parse('{"name":"para cada", "mandatory_params":[], "optional_params":{}}'))
         step_list = step_list.concat(JSON.parse('{"name":"for each page in", "mandatory_params":[], "optional_params":{}}'))
         step_list = step_list.concat(JSON.parse('{"name":"abrir em nova aba", "mandatory_params":[], "optional_params":{}}'))
+        step_list = step_list.concat(JSON.parse('{"name":"fechar aba", "mandatory_params":[], "optional_params":{}}'))
         init_steps_creation_interface(interface_root_element, output_element, step_list)
       }
     };

--- a/src/step-by-step/step_crawler/code_generator.py
+++ b/src/step-by-step/step_crawler/code_generator.py
@@ -111,6 +111,15 @@ def generate_salva_pagina(child, module):
     code += "await salva_pagina(**missing_arguments)\n"
     return code
 
+def generate_abrir_em_nova_aba(child, module):
+    code = ""
+    code += child['depth'] * '    ' + 'page_stack.append(page)\n'
+    code += child['depth'] * '    ' + \
+            'missing_arguments["page"] = await open_in_new_tab(**missing_arguments, ' + \
+                'link_xpath = ' + child['link_xpath'] +')\n'
+    code += child['depth'] * '    ' + 'page = missing_arguments["page"]\n'
+    return code
+
 
 def generate_call_step(child, module):
     code = ""
@@ -152,7 +161,8 @@ def generate_head(module):
     code += "from " + module.__name__ + " import *\n\n"
     code += "async def execute_steps(**missing_arguments):\n"\
         + "    pages = {}\n"\
-        + "    page = missing_arguments['page']\n"
+        + "    page = missing_arguments['page']\n"\
+        + "    page_stack = []\n"
     return code
 
 
@@ -180,4 +190,5 @@ def generate_code(recipe, module):
     code += generate_body(recipe, module)
     code += "    return pages"
     print(code)
+    print('--------------------------------------------------------------------------')
     return RuntimeModule.from_string("steps", code)

--- a/src/step-by-step/step_crawler/code_generator.py
+++ b/src/step-by-step/step_crawler/code_generator.py
@@ -120,6 +120,13 @@ def generate_abrir_em_nova_aba(child, module):
     code += child['depth'] * '    ' + 'page = missing_arguments["page"]\n'
     return code
 
+def generate_fechar_aba(child, module):
+    code = ""
+    code += child['depth'] * '    ' + 'await page.close()\n'
+    code += child['depth'] * '    ' + 'missing_arguments["page"] = page_stack.pop()\n'
+    code += child['depth'] * '    ' + 'page = missing_arguments["page"]\n'
+    return code
+
 
 def generate_call_step(child, module):
     code = ""

--- a/tests/test_step_by_step/code_generator_test.py
+++ b/tests/test_step_by_step/code_generator_test.py
@@ -59,6 +59,7 @@ class TestExtractInfo(unittest.TestCase):
         expected_result += "execute_steps(**missing_arguments):\n"
         expected_result += "    pages = {}\n"
         expected_result += "    page = missing_arguments['page']\n"
+        expected_result += "    page_stack = []\n"
         self.assertEqual(expected_result, result)
 
     def test_generate_body(self):


### PR DESCRIPTION
Estes passos estão sendo adicionados para solucionar casos em que o passo 'Retorna página' não pode ser utilizado para ir e voltar de páginas na coleta. Isso é verdade na coleta #305 por exemplo, em que a página de resultados gerada pelo formulário é recarregada para seu estado original (como se tivesse sido aberta pela primeira vez) toda vez que entramos em algum link e clicamos no botão de voltar no navegador.

A solução criada é a de 'Abrir em nova aba'. Este passo funciona de forma parecida ao passo de clique, onde um xpath deve ser fornecido, e o coletor irá clicar no elemento apontado por ele, com o adendo de que agora caso o elemento seja um link, ele será aberto em uma nova guia do navegador do web driver. 

A partir dai, todos os passos que seguem serão executados nesta nova aba, até que o passo de 'Fechar aba' seja usado. Este, por sua vez, faz o papel de fechar a última aba aberta pelo coletor e voltar o contexto para a página anterior.