### PR TITLE
Issue 773 - Passo de digitar não sobrescreve a caixa de texto

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -126,6 +126,7 @@ async def retorna_pagina(pagina):
 
 @step("Digitar em")
 async def digite(pagina, xpath, texto):
+    await pagina.querySelectorEval(cssify(xpath), 'el => el.value = ""')
     await pagina.type(cssify(xpath), texto)
 
 


### PR DESCRIPTION
Corrige pequeno bug em que o passo de digitar não sobrescreve o que já estava escrito no elemento apontado antes de escrever o novo texto.