### PR TITLE
Issue 766 - Clique em botões não funciona corretamente

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -82,11 +82,11 @@ async def clique(pagina, elemento):
         await pagina.waitForXPath(elemento)
         elements = await pagina.xpath(elemento)
         if len(elements) == 1:
-            await elements[0].click()
+            await pagina.evaluate('element => { element.click(); }', elements[0])
         else:
             raise Exception('XPath points to non existent element, or multiple elements!')
     else:
-        elemento.click()
+        await pagina.evaluate('element => { element.click(); }', elemento)
     await espere_pagina(pagina)
 
 
@@ -220,8 +220,7 @@ async def open_in_new_tab(pagina, link_xpath):
     new_page_promisse = asyncio.get_event_loop().create_future()
     if len(elements) == 1:
         pagina.browser.once("targetcreated", lambda target: new_page_promisse.set_result(target))
-        await pagina.evaluate('el => el.setAttribute("target", "_blank")', elements[0])
-        await elements[0].click()
+        await pagina.evaluate('el => { el.setAttribute("target", "_blank"); el.click();}', elements[0])
         await pagina.bringToFront()
     else:
         raise Exception('XPath points to non existent element, or multiple elements!')


### PR DESCRIPTION
Idenfiticamos um bug em que algumas páginas possuem botoes e links que não funcionam corretamente com a função de clique atual. Percebi que isso se dá por conta de uma instabilidade da própria função de click() do Pyppeteer.

Por isso, troquei as ocorrências dessa função para uma chamada de evaluate, fazendo dessa forma a mesma chamada, só que usando javascript diretamente na pagina.