### PR TITLE
Issue 764 - Travamento do scrapy em coletas dinâmicas 

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -217,17 +217,19 @@ async def elemento_existe_na_pagina(pagina, xpath):
 async def open_in_new_tab(pagina, link_xpath):
     await pagina.waitForXPath(link_xpath)
     elements = await pagina.xpath(link_xpath)
-    new_page_promisse = asyncio.get_event_loop().create_future()
-    if len(elements) == 1:
-        pagina.browser.once("targetcreated", lambda target: new_page_promisse.set_result(target))
-        await pagina.evaluate('el => el.setAttribute("target", "_blank")', elements[0])
-        await elements[0].click()
-        await pagina.bringToFront()
-    else:
+
+    if len(elements) != 1:
         raise Exception('XPath points to non existent element, or multiple elements!')
 
-    new_page = await (await new_page_promisse).page()
-    await espere_pagina(new_page)
-    await new_page.bringToFront()
+    new_page_promisse = asyncio.get_event_loop().create_future()
+    pagina.browser.once("targetcreated", lambda target: new_page_promisse.set_result(target))
+    await pagina.evaluate('el => el.setAttribute("target", "_blank")', elements[0])
+    await elements[0].click()
+    try:
+        new_page = await (await asyncio.wait_for(new_page_promisse, 60)).page()
+        await espere_pagina(new_page)
+        await new_page.bringToFront()
 
-    return new_page
+        return new_page
+    except asyncio.TimeoutError:
+        raise Exception('Process timed out when trying to open xpath "' + link_xpath +'" in a new page!')


### PR DESCRIPTION
Esse comportamento de travamento foi identificado em algumas coletas em que o passo de abrir em nova aba estava sendo utilizado. Identifiquei que o problema estava relacionado a utilização assincrona do Pyppeteer. 

O erro ocorria quando o clique no xpath apontado não gerava nenhuma navegação na página (relacionado a issue #766), ou seja, uma nova aba não seria aberta. Quando isso acontecia, o programa ficava travando esperando na linha [229](https://github.com/MPMG-DCC-UFMG/C01/blob/e307c6ae49f48240acf75c875acbf656ee052edd/src/step-by-step/step_crawler/functions_file.py#L229) para sempre. Para resolver, coloquei um timeout de 1 minuto para que uma nova aba seja aberta. Caso a navegação nunca aconteça, o timeout gera uma exeção e a coleta termina com erro.