### PR TITLE
Issue 868 - Resolve bug de páginas sendo salvas incompletas por limpeza de HTML

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -13,7 +13,6 @@ import json
 import itertools
 import os
 import re
-from lxml.html.clean import Cleaner
 import mimetypes
 import requests
 import string
@@ -262,14 +261,8 @@ class BaseSpider(scrapy.Spider):
                 f.write(raw_body)
 
         else:
-            cleaner = Cleaner(
-                style=True, links=False, scripts=True,
-                comments=True, page_structure=False
-            )
-
-            body = cleaner.clean_html(raw_body.decode(encoding))
             with open(file=relative_path, mode="w+", encoding=encoding, errors='ignore') as f:
-                f.write(body)
+                f.write(raw_body.decode(encoding))
 
 
         self.feed_file_description(


### PR DESCRIPTION
Algumas páginas com informações dinâmicas não estavam sendo salvas por completo devido ao processamento do HTML para limpá-lo. Para resolver esse bug de maneira definitiva, foi removido o tratamento de limpeza do HTML, que, embora deva tornar as coletas maiores, não acarretará problemas futuros. Eventualmente, caso necessário, novas maneiras de tratar o HTML devem ser desenvolvidas.

Para testar, basta executar a coleta presente na documentação da issue #868 e verificar o HTML salvo na versão sem e com correção.

close #868 