### PR TITLE
Issue 843 - Corrige erro ao baixar arquivos em páginas dinâmicas.

### DIFF
--- a/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
+++ b/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
@@ -129,6 +129,10 @@ class PuppeteerMiddleware:
             await self.browser.newPage()
             page = await self.browser.newPage()
 
+            # Changes the default file save location.
+            cdp = await page._target.createCDPSession()
+            await cdp.send('Browser.setDownloadBehavior', {'behavior': 'allowAndName', 'downloadPath': self.download_path})
+
         # Cookies
         if isinstance(request.cookies, dict):
             await page.setCookie(*[

--- a/tests/test_scrapy_puppeteer/test_middlewares.py
+++ b/tests/test_scrapy_puppeteer/test_middlewares.py
@@ -122,6 +122,7 @@ class ScrapyPuppeteerTestCase(unittest.TestCase):
         # _from_crawler call (using mock values)
         middleware.data_path = ""
         middleware.instance_id = 0
+        middleware.download_path = ""
 
         return middleware
 


### PR DESCRIPTION
O erro ocorre porque sempre uma exceção é levantada dentro do método `_process_request` de `scrapy_puppeteer/middlewares.py` ao chamar `page = await self.browser.newPage()` logo no início do método.

Embora haja tratamento para essa exceção, foi esquecido de adicionar nela o código responsável por habilitar download de arquivos.

Como essa exceção ocorre com frequência, a issue #895 foi criada para cuidar dela em algum outro momento.

Mas já com a solução dessa PR as coletas devem executar os downloads corretamente.