### PR TITLE
[Master] Issue 960 - Evita `exceção silenciosa` ao detectar encoding de página

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -216,9 +216,7 @@ class BaseSpider(scrapy.Spider):
             'encoding_detection_method', CrawlRequest.HEADER_ENCODE_DETECTION)
 
         if encoding_detection_method == CrawlRequest.HEADER_ENCODE_DETECTION:
-            content_type = response.headers['Content-type'].decode()
-            _, params = cgi.parse_header(content_type)
-            encoding = params['charset']
+            encoding = response.encoding
 
         elif encoding_detection_method == CrawlRequest.AUTO_ENCODE_DETECTION:
             detection = chardet.detect(response.body)


### PR DESCRIPTION
O método de detecção de encoding via resposta do servidor foi alterado de modo a deixar de realizar parsing no `content-type` da resposta do servidor para usar o encoding informado pelo servidor diretamente.

Resolve issue #960. 