### PR TITLE
Issue 928 - Adição do passo "Extrair Propriedade" no mecanismo de passos

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -113,6 +113,17 @@ async def extrai_texto(pagina, xpath):
     text = await pagina.Jeval(cssify(xpath), "el => el.textContent")
     return text
 
+@step("Extrair propriedade de")
+async def extrai_propriedade(pagina, xpath, propriedade):
+    await pagina.waitForXPath(xpath)
+    elements = await pagina.xpath(xpath)
+    if len(elements) == 1:
+        text = await pagina.evaluate("el => el.getAttribute(\"" + propriedade + "\")", elements[0])
+    else:
+        raise Exception('XPath points to non existent element, or multiple elements!')
+    
+    return text
+
 
 @step("Opções")
 async def opcoes(pagina, xpath, exceto=None):


### PR DESCRIPTION
Como planejado para essa sprint, esta nova função poderá ser utilizada em casos em que alguma informação presente em alguma propriedade dos elementos da página sendo coletada poderia ser utilizada na coleta.

Para utiliza-la, basta passar o xpath do elemento e o id da propriedade a ser extraida. Dessa forma, em conjunto com o passo de atribuição, essa informação pode então ser utilizada em passos subsequentes no pipeline de coleta.