### PR TITLE
Issue 1209 - Desabilita o interceptador de requisições no Pyppeteer 

### DIFF
--- a/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
+++ b/src/scrapy_puppeteer/scrapy_puppeteer/middlewares.py
@@ -197,7 +197,7 @@ class PuppeteerMiddleware:
         async def stop_request_interceptor(page) -> None:
             await page._networkManager._client.send("Fetch.disable")
 
-        await setup_request_interceptor(page)
+        # await setup_request_interceptor(page)
 
         try:
             response = await page.goto(
@@ -212,7 +212,7 @@ class PuppeteerMiddleware:
             raise IgnoreRequest()
 
         # Stop intercepting following requests
-        await stop_request_interceptor(page)
+        # await stop_request_interceptor(page)
 
         if request.screenshot:
             request.meta['screenshot'] = await page.screenshot()


### PR DESCRIPTION
O trecho de código responsável por interceptar requisições do pyppeteer e que provocava problemas de conexão e bloqueios com servidores foi desabilitado, pois estava sem utilidade até o momento mas poderá ser reativado, possivelmente de outra forma, futuramente.

Agora, as coletas afetadas por esse problema se comportam como na master.

Resolve issues: #997, #996 e #994.