### PR TITLE
Issue 1356 - Generalização da Função "Localizar Elementos"

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -151,16 +151,45 @@ async def for_clicavel(pagina, xpath):
 
 
 @step("Localizar elementos")
-async def localiza_elementos(pagina, xpath, numero_xpaths=None):
-    base_xpath = xpath.split("[*]")[0]
-
+async def localiza_elementos(pagina, xpath, numero_xpaths=None, modo='simples'):
     xpath_list = []
-    for i in range(len(await pagina.xpath(base_xpath))):
-        candidate_xpath = xpath.replace("*", str(i + 1))
-        if await elemento_existe_na_pagina(pagina, candidate_xpath):
-            xpath_list.append(candidate_xpath)
+
+    if modo == 'complexo':
+        elements = await pagina.xpath(xpath)
+        for el in elements:
+            text = await pagina.evaluate("""el => { 
+                var getXpathOfNode = (domNode, bits) => {
+                    bits = bits ? bits : [];
+                    var c = 0;
+                    var b = domNode.nodeName;
+                    var p = domNode.parentNode;
+
+                    if (p) {
+                        var els = p.getElementsByTagName(b);
+                        if (els.length >  1) {
+                        while (els[c] !== domNode) c++;
+                        b += "[" + (c+1) + "]";
+                        }
+                        bits.push(b);
+                        return getXpathOfNode(p, bits);
+                    }
+                    return bits.reverse().join("/");
+                }; 
+                return getXpathOfNode(el);
+            }""", el)
+
+            xpath_list.append(text.lower())
+        
+    elif modo == 'simples':
+        base_xpath = xpath.split("[*]")[0]
+
+        for i in range(len(await pagina.xpath(base_xpath))):
+            candidate_xpath = xpath.replace("*", str(i + 1))
+            if await elemento_existe_na_pagina(pagina, candidate_xpath):
+                xpath_list.append(candidate_xpath)
 
     numero_xpaths = len(xpath_list) if not numero_xpaths else numero_xpaths
+
     return xpath_list[:numero_xpaths]
 
 


### PR DESCRIPTION
Este pull request resolve o problema do passo de localizar elementos não funcionar com xpaths mais complexos (que contenham mais de um sinal de  ´*´, por exemplo).

Para utilizar essa nova implementacao, basta passar um novo parametro opcional na interface: 'modo'. Sem utilizar esse atributo ou setando ele para 'simples', o passo sera executado pelo metodo antigo (mantive por questoes de compatibilidade). Para utilizar a nova funcionalidade, basta setar o atributo para 'complexo'.

Exemplo de teste: Com esse novo modo espera-se que uma chamada com o xpath '//a[@href]' retorne os xpaths de todos os links da pagina.