### PR TITLE
Issue 2560 - Adição ao suporte de opções de campo para os argumentos dos passos

### DIFF
--- a/main/staticfiles/js/step_block.js
+++ b/main/staticfiles/js/step_block.js
@@ -216,6 +216,8 @@ function generate_input_html(param_name, param_display, field_options){
  * an input element to obtain the value to be setted
  * for this parameter. This function is a method of block.
  * @param {String} param_name The name of the param to be added.
+ * @param {Dict} field_options A dictionary containing options 
+ * regarding the field which will be created for the parameter
  * @param {Bool} optional_param A boolean that says whether or
  *               not the parameter is optional
  */

--- a/main/staticfiles/js/step_block.js
+++ b/main/staticfiles/js/step_block.js
@@ -167,13 +167,48 @@ function init_optional_params_button(step){
     for(child of dropdown_menu.children){
         child.onclick = function(){
             block = find_parent_with_attr_worth(this, "block")
-            block.add_param(this.dataset.param, true)
+            param = this.dataset.param
+            field_options = step.field_options[param]
+            block.add_param(param, field_options, true)
             hide(this)
         }
     }
 
     block.new_parameter_button.dropdown_menu = dropdown_menu
     block.lines[last_line].appendChild(block.new_parameter_button_box)
+}
+
+function generate_input_html(param_name, param_display, field_options){
+    if (field_options == undefined){
+        return `<input type="text" placeholder="${param_display}" class="row form-control" data-param="${param_name}" data-type="text" />`
+    }
+
+    field_type = field_options['field_type']
+    innerHTML = ''
+
+    switch(field_type){
+        case 'text':
+        case 'number':
+            placeholder = field_options['input_placeholder'] == undefined ?  param_display : field_options['input_placeholder']
+            innerHTML = `<input type="${field_type}" placeholder="${placeholder}" class="row form-control" data-param="${param_name}" data-type="text" />`
+            break;
+        case 'checkbox':
+            label = field_options['checkbox_label']
+            innerHTML = `<input type="${field_type}" id="${param_name}" class="form-check-input" data-param="${param_name}" data-type="bool"/>`
+            innerHTML += `<label for="${param_name}" class="form-check-label">${label}</label>`
+            break;
+        case 'select':
+            options = field_options['select_options']
+            innerHTML += `<select class="row form-control" id="${param_name}" data-param="${param_name}" data-type="text">`
+            innerHTML += `<option value="" disabled selected>${param_display}</option>`
+            for(option of options){
+                innerHTML += `<option value="${option}">${option}</option>`
+            }
+            innerHTML += `</select>`
+            break;
+    }
+
+    return innerHTML
 }
 
 /**
@@ -184,7 +219,7 @@ function init_optional_params_button(step){
  * @param {Bool} optional_param A boolean that says whether or
  *               not the parameter is optional
  */
-function add_param(param_name, optional_param = false){
+function add_param(param_name, field_options, optional_param = false){
     block = find_parent_with_attr_worth(this, "block")
     last_line = block.lines.length-1
     if(block.lines[last_line].row.full){
@@ -199,7 +234,8 @@ function add_param(param_name, optional_param = false){
     param_element = document.createElement("DIV")
     param_element.className = "col-sm"
     param_display = param_to_placeholder(param_name)
-    param_element.innerHTML = `<input placeholder="${param_display}" class="row form-control" data-param="${param_name}">`
+
+    param_element.innerHTML = generate_input_html(param_name, param_display, field_options)
 
     if(optional_param){
         remove_button = document.createElement("A")
@@ -311,7 +347,8 @@ function refresh_iterable(){
     block.add_line()
 
     for(param of block.iterable_step.mandatory_params){
-        block.add_param(param)
+        field_options = block.iterable_step.field_options[param]
+        block.add_param(param, field_options)
     }
 
     optional_params = Object.keys(block.iterable_step.optional_params)
@@ -333,7 +370,8 @@ function refresh_iterable(){
     block.add_line()
 
     for(param of block.condition_step.mandatory_params){
-        block.add_param(param)
+        field_options = block.condition_step.field_options[param]
+        block.add_param(param, field_options)
     }
 
     optional_params = Object.keys(block.condition_step.optional_params)
@@ -356,7 +394,8 @@ function refresh_source(){
     block.add_line()
 
     for(param of block.source_step.mandatory_params){
-        block.add_param(param)
+        field_options = block.source_step.field_options[param]
+        block.add_param(param, field_options)
     }
 
     optional_params = Object.keys(block.source_step.optional_params)
@@ -584,7 +623,8 @@ function refresh_step(){
         block.add_line()
         
         for(param of block.step.mandatory_params){
-            block.add_param(param)
+            field_options = block.step.field_options[param]
+            block.add_param(param, field_options)
         }
         
         optional_params = Object.keys(block.step.optional_params)

--- a/main/staticfiles/js/steps.js
+++ b/main/staticfiles/js/steps.js
@@ -235,21 +235,21 @@ function load_steps(json_steps, step_list){
 }
 
 function refill_parameters(args, block){
-    for(arg in args){
-        let param_input = $(block).find("input,select[data-param=" + arg + "]")
+    for(let arg in args){
+        let param_input = $(block).find("input[data-param=" + arg + "],select[data-param=" + arg + "]")
 
         if(param_input.length == 0){
             let dropdown_entry = $(block.new_parameter_button.dropdown_menu).find("a[data-param=" + arg + "]")
 
             if(dropdown_entry.length != 0){
                 dropdown_entry.click()
-                param_input = $(block).find("input,select[data-param=" + arg + "]")
+                param_input = $(block).find("input[data-param=" + arg + "],select[data-param=" + arg + "]")
             }else{
                 // TODO: warn user, argument not found
                 continue
             }
         }
-        if (typeof args[arg] === 'boolean') {
+        if (typeof args[arg] == 'boolean') {
             param_input.prop('checked', args[arg]);
         } else {
             param_input.val(args[arg])
@@ -364,10 +364,10 @@ function get_step_json_format(block){
  * @return {Dict} dict The step object filled with configured parameters.
  */
 function load_param_dict(block){
-    dict = {}
-    for(param of block.params){
-        param_name = param.children[0].dataset.param
-        field_type = param.children[0].type
+    let dict = {}
+    for(let param of block.params){
+        let param_name = param.children[0].dataset.param
+        let field_type = param.children[0].type
         if (field_type == "checkbox") {
             dict[param_name] = param.children[0].checked
         } else {

--- a/main/staticfiles/js/steps.js
+++ b/main/staticfiles/js/steps.js
@@ -236,20 +236,24 @@ function load_steps(json_steps, step_list){
 
 function refill_parameters(args, block){
     for(arg in args){
-        let param_input = $(block).find("input[data-param=" + arg + "]")
+        let param_input = $(block).find("input,select[data-param=" + arg + "]")
 
         if(param_input.length == 0){
             let dropdown_entry = $(block.new_parameter_button.dropdown_menu).find("a[data-param=" + arg + "]")
 
             if(dropdown_entry.length != 0){
                 dropdown_entry.click()
-                param_input = $(block).find("input[data-param=" + arg + "]")
+                param_input = $(block).find("input,select[data-param=" + arg + "]")
             }else{
                 // TODO: warn user, argument not found
                 continue
             }
         }
-        param_input.val(args[arg])
+        if (typeof args[arg] === 'boolean') {
+            param_input.prop('checked', args[arg]);
+        } else {
+            param_input.val(args[arg])
+        }
     }
 }
 
@@ -360,10 +364,15 @@ function get_step_json_format(block){
  * @return {Dict} dict The step object filled with configured parameters.
  */
 function load_param_dict(block){
-    let dict = {}
-    for(let param of block.params){
-        let param_name = param.children[0].dataset.param
-        dict[param_name] = param.children[0].value
+    dict = {}
+    for(param of block.params){
+        param_name = param.children[0].dataset.param
+        field_type = param.children[0].type
+        if (field_type == "checkbox") {
+            dict[param_name] = param.children[0].checked
+        } else {
+            dict[param_name] = param.children[0].value
+        }
     }
     return dict
 }

--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -18,11 +18,12 @@ from pyext import RuntimeModule
 """
 
 
-def step(display, executable_contexts=['page', 'tab', 'iframe']):
+def step(display, field_options = {}, executable_contexts=['page', 'tab', 'iframe']):
     def function(f):
         f.is_step = True
         f.display = display
         f.executable_contexts = executable_contexts
+        f.field_options = field_options
         return f
 
     return function
@@ -39,7 +40,8 @@ def repete(vezes):
     return [i for i in range(vezes)]
 
 
-@step("Esperar")
+@step("Esperar", field_options = {
+    'segundos' : {'field_type' : 'number', 'input_placeholder' : 'Espera em segundos'}})
 def espere(segundos):
     time.sleep(segundos)
 
@@ -152,11 +154,12 @@ async def for_clicavel(pagina, xpath):
         return False
 
 
-@step("Localizar elementos")
-async def localiza_elementos(pagina, xpath, numero_xpaths=None, modo='simples'):
+@step("Localizar elementos", field_options = {
+    'modo' : {'field_type' : 'select', 'select_options' : ["'Modo Simples'","'XPath Complexos'"]}})
+async def localiza_elementos(pagina, xpath, numero_xpaths=None, modo='Modo Simples'):
     xpath_list = []
 
-    if modo == 'complexo':
+    if modo == 'XPath Complexos':
         elements = await pagina.xpath(xpath)
         for el in elements:
             text = await pagina.evaluate("""el => { 
@@ -182,7 +185,7 @@ async def localiza_elementos(pagina, xpath, numero_xpaths=None, modo='simples'):
 
             xpath_list.append(text.lower())
         
-    elif modo == 'simples':
+    elif modo == 'Modo Simples':
         base_xpath = xpath.split("[*]")[0]
 
         for i in range(len(await pagina.xpath(base_xpath))):
@@ -270,7 +273,8 @@ async def elemento_existe_na_pagina(pagina, xpath):
     return True
 
 
-@step("Comparação")
+@step("Comparação", field_options = {
+    'comp' : {'field_type' : 'select', 'select_options' : ["'=='","'<='", "'>='", "'<'", "'>'", "'!='"]}})
 async def comparacao(pagina, arg1, comp, arg2):
     """This step returns the result of comp(arg1, arg2)
 

--- a/src/step-by-step/step_crawler/parameter_extractor.py
+++ b/src/step-by-step/step_crawler/parameter_extractor.py
@@ -22,6 +22,7 @@ def extract_info(func, ignore_params=None):
 
     optional_params = dict()
     mandatory_params = list()
+    field_options = func.field_options
     signature = inspect.signature(func)
     for k, v in signature.parameters.items():
         if v.default is not inspect.Parameter.empty:
@@ -30,12 +31,14 @@ def extract_info(func, ignore_params=None):
             if k not in ignore_params:
                 mandatory_params.append(k)
 
+
     func_info = {
         'name': name,
         'name_display': name_display,
         'executable_contexts': executable_contexts,
         'mandatory_params': mandatory_params,
         'optional_params': optional_params,
+        'field_options': field_options,
     }
     return func_info
 

--- a/tests/test_step_by_step/examples/functions_file_example.py
+++ b/tests/test_step_by_step/examples/functions_file_example.py
@@ -21,3 +21,9 @@ def only_optional_params(some="some", parameters="parameters", to="to",
 @step("No params")
 def no_params():
     return [1, 2]
+
+
+@step("With params and field_options", field_options = {
+    'test' : {'field_type' : 'number', 'input_placeholder' : 'test'}})
+def with_params_and_field_options(test):
+    return test

--- a/tests/test_step_by_step/parameter_extractor_test.py
+++ b/tests/test_step_by_step/parameter_extractor_test.py
@@ -18,7 +18,8 @@ class TestExtractInfo(unittest.TestCase):
             "optional_params": {
                 "to": 1,
                 "test": None
-            }
+            },
+            'field_options': {}
         },
         {
             "name": "only_mandatory_params",
@@ -30,7 +31,8 @@ class TestExtractInfo(unittest.TestCase):
                 "to",
                 "test"
             ],
-            "optional_params": {}
+            "optional_params": {},
+            'field_options': {}
         },
         {
             "name": "only_optional_params",
@@ -42,14 +44,26 @@ class TestExtractInfo(unittest.TestCase):
                 "parameters": "parameters",
                 "to": "to",
                 "test": "test"
-            }
+            },
+            'field_options': {}
         },
         {
             "name": "no_params",
             "executable_contexts": ["page", "tab", "iframe"],
             "name_display": "No params",
             "mandatory_params": [],
-            "optional_params": {}
+            "optional_params": {},
+            'field_options': {}
+        },
+        {
+            "name": "with_params_and_field_options",
+            "executable_contexts": ["page", "tab", "iframe"],
+            "name_display": "With params and field_options",
+            "mandatory_params": [
+                "test"
+            ],
+            "optional_params": {},
+            "field_options": {"test" : {"field_type" : "number", "input_placeholder" : "test"}}
         }
     ]
 
@@ -71,7 +85,7 @@ class TestExtractInfo(unittest.TestCase):
 
         # Because they may be out of order, and contains unhashable items
         self.assertEqual(
-            [i in result for i in self.expected_results], [1, 1, 1, 1])
+            [i in result for i in self.expected_results], [1, 1, 1, 1, 1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Até o momento, a interface do mecanismo de passos somente suportava a utilização de campos de texto para os argumentos de cada passo.

Este PR adiciona o suporte para a configuração de opções para os argumentos de uma função no mecanismo de passos. Isso pode ser feito através das anotações `@step` utilizadas em cada função, onde um novo argumento `field_options` pode ser utilizado. Ele recebe um dicionário de configuração onde cada argumento da função pode ser configurado com outro dicionário que aceita as seguintes propriedades:

`'field_type'` : Tipo do campo a ser utilizado. Atualmente aceita 'text', 'select', 'number', 'checkbox'.

`'select_options' `: Para ser utilizado em conjunto com o tipo 'select'. Recebe uma lista de strings que será utilizada como opções no campo de seleção.

`'checkbox_label'` : Para ser utilizado em conjunto com o tipo 'checkbox'. Recebe uma string que sera utilizada como label para o checkbox na interface.

`'input_placeholder '` : Para ser utilizado em conjunto com o tipo 'text' e 'number'. Recebe uma string que aparecerá como placeholder para o campo na interface.

Essa nova função do mecanismo de passos é opcional, e caso não seja utilizada pra algum argumento, o seu campo na interface será padronizado para um campo de texto comum.



