### PR TITLE
Tornando a porta configurável na finalização dos crawlers

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -29,6 +29,8 @@ from crawlers.injector_tools import create_probing_object,\
 from main.models import CrawlRequest
 from crawlers.constants import AUTO_ENCODE_DETECTION_CONFIDENCE_THRESHOLD
 
+from crawlers.port import *
+
 PUNCTUATIONS = "[{}]".format(string.punctuation)
 
 
@@ -465,7 +467,6 @@ class BaseSpider(scrapy.Spider):
     def spider_closed(self, spider):
         crawler_id = spider.crawler.settings.get('CRAWLER_ID')
 
-        # TODO: get port as variable
-        port = 8000
+        # PORT comes from the port module and is set on run.py directly from CLI input
         requests.get(
-            f'http://localhost:{port}/detail/stop_crawl/{crawler_id}')
+            f'http://localhost:{PORT}/detail/stop_crawl/{crawler_id}')

--- a/run.py
+++ b/run.py
@@ -41,6 +41,16 @@ def run_django():
     signal.signal(signal.SIGCHLD, lambda _, __: os.wait())
     wait_for_port(9092)
 
+    # gets port from CLI parameter and sets module to be used on spider_closed()
+    if (len(sys.argv[1:]) == 0):
+        cli_port = 8000
+    else:
+        cli_port = str(sys.argv[1]).split(":",1)[1]
+    
+    f = open("./crawlers/port.py", "w") 
+    f.write("PORT="+str(cli_port)) 
+    f.close()
+
     # Runs django repassing cli parameters
     subprocess.run(["python", "manage.py", "runserver"] + sys.argv[1:])
 


### PR DESCRIPTION
A issue #2559 se modificou algumas vezes desde que comecei a trabalhar na mesma, mas por fim, a modificação necessária é ajustar a configuração da porta em que o servidor é rodado, pois estava hardcoded para a 8000 e agora temos uma instância rodando na 8001 também.
Como a porta é setada apenas na chamada do run.py pelo cli, foi preciso pegar o parâmetro da porta neste momento e criar um arquivo de configuração para ser importado no momento de finalizar o crawler, o que antes setado manualmente acarretava na não finalização do crawler.

Para testar, basta rodar na porta 8001 e colocar um coletor para rodar. Quando ele for naturalmente finalizado, o status da coleta deve atualizar sozinho para "Parado".

Closes #2559 