### PR TITLE
Conserta valores default inválidos de SECRET_KEY

### DIFF
--- a/interface/settings.py
+++ b/interface/settings.py
@@ -37,7 +37,9 @@ env = environ.Env(
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env('SECRET_KEY', default=get_random_secret_key())
+SECRET_KEY = env('SECRET_KEY', default=None)
+if SECRET_KEY is None:
+    SECRET_KEY = get_random_secret_key()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env('DEBUG')


### PR DESCRIPTION
O valor default desse parâmetro agora é atribuído fora da biblioteca Django-environ, evitando erros quando o valor gerado começa com o caractere '$'.

Closes #3903.