### PR TITLE
Issue 2625 - Adiciona campos de configuração ao coletor

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -20,6 +20,9 @@ class CrawlRequestForm(forms.ModelForm):
             'form_request_type',
             'obey_robots',
             'captcha',
+            'crawler_description',
+            'crawler_type_desc',
+            'crawler_issue',
 
             'sc_scheduler_persist',
             'sc_scheduler_queue_refresh',
@@ -117,6 +120,27 @@ class RawCrawlRequestForm(CrawlRequestForm):
         help_text="Esse caminho deve ser único para cada coletor. Caso a pasta não esteja criada, o coletor a criará automaticamente.",
         validators=[CrawlRequest.pathValid]
     )
+
+    crawler_description = forms.CharField(
+        label="Descrição do coletor",
+        widget=forms.TextInput(
+            attrs={'placeholder': 'Descrição geral do coletor, por exemplo, município e ano alvo de coleta.'})
+    )
+
+    crawler_type_desc = forms.ChoiceField(
+        choices=(
+            ('Contratos', 'Contratos'),
+            ('Despesas', 'Despesas'),
+            ('Diários', 'Diários'),
+            ('Licitação', 'Licitação'),
+            ('Processos', 'Processos'),
+            ('Servidores', 'Servidores'),
+            ('Transparência', 'Transparência'),
+            ('Outro', 'Outro'),
+        )
+    )
+
+    crawler_issue = forms.IntegerField(required=False, initial=0, label='Issue')
 
     # SCRAPY CLUSTER ##########################################################
 

--- a/main/forms.py
+++ b/main/forms.py
@@ -133,6 +133,7 @@ class RawCrawlRequestForm(CrawlRequestForm):
             ('Despesas', 'Despesas'),
             ('Diários', 'Diários'),
             ('Licitação', 'Licitação'),
+            ('Não Informado', 'Não Informado'),
             ('Processos', 'Processos'),
             ('Servidores', 'Servidores'),
             ('Transparência', 'Transparência'),

--- a/main/forms.py
+++ b/main/forms.py
@@ -129,6 +129,7 @@ class RawCrawlRequestForm(CrawlRequestForm):
     )
 
     crawler_type_desc = forms.ChoiceField(
+        label="Tipo do coletor",
         choices=(
             ('Contratos', 'Contratos'),
             ('Despesas', 'Despesas'),

--- a/main/models.py
+++ b/main/models.py
@@ -32,7 +32,22 @@ class CrawlRequest(TimeStamped):
     source_name = models.CharField(max_length=200)
     base_url = models.TextField()
     obey_robots = models.BooleanField(blank=True, null=True)
+    crawler_description = models.TextField( default='')
+    CRAWLERS_TYPES = [
+        ('Contratos', 'Contratos'),
+        ('Despesas', 'Despesas'),
+        ('Diários', 'Diários'),
+        ('Licitação', 'Licitação'),
+        ('Processos', 'Processos'),
+        ('Servidores', 'Servidores'),
+        ('Transparência', 'Transparência'),
+        ('Outro', 'Outro'),
+    ]
+    crawler_type_desc = models.CharField(max_length=15,
+                                    choices=CRAWLERS_TYPES,
+                                    default='Licitação')
 
+    crawler_issue = models.PositiveIntegerField(default=0)
     # This regex is a bit convolute, but in summary: it allows numbers,
     # letters, dashes and underlines. It allows forward and backward slashes
     # unless it occurs in the first character (since we don't allow absolute

--- a/main/models.py
+++ b/main/models.py
@@ -38,6 +38,7 @@ class CrawlRequest(TimeStamped):
         ('Despesas', 'Despesas'),
         ('Diários', 'Diários'),
         ('Licitação', 'Licitação'),
+        ('Não Informado', 'Não Informado'),
         ('Processos', 'Processos'),
         ('Servidores', 'Servidores'),
         ('Transparência', 'Transparência'),
@@ -45,7 +46,7 @@ class CrawlRequest(TimeStamped):
     ]
     crawler_type_desc = models.CharField(max_length=15,
                                     choices=CRAWLERS_TYPES,
-                                    default='Licitação')
+                                    default='Não Informado')
 
     crawler_issue = models.PositiveIntegerField(default=0)
     # This regex is a bit convolute, but in summary: it allows numbers,

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -270,6 +270,9 @@ New Crawler
                                 <hr>
                                 {{ form.expected_runtime_category | as_crispy_field }}
                                 <hr>
+                                {{ form.crawler_type_desc | as_crispy_field}}
+                                {{ form.crawler_description | as_crispy_field}}
+                                {{ form.crawler_issue | as_crispy_field}}
                                 {{ form.obey_robots | as_crispy_field}}
                                 {{ form.data_path | as_crispy_field}}
                             </div>

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -19,6 +19,9 @@ Crawler "{{ crawler.source_name }}"
                 <li>ID do coletor: <strong>{{ crawler.id }}</strong></li>
                 <li>URL base: <strong><a href="{{ crawler.base_url }}" target="_blank">{{ crawler.base_url }}</a></strong></li>
                 <li>Data de criação: <strong>{{ crawler.creation_date }}</strong></li>
+                <li>Tipo de coleta: <strong>{{crawler.crawler_type_desc}}</strong></li>
+                <li>Descrição: <strong>{{crawler.crawler_description}}</strong></li>
+                <li>Issue: <a href="https://github.com/MPMG-DCC-UFMG/C01/issues/{{crawler.crawler_issue}}" target="_blank"><strong>{{crawler.crawler_issue}}</strong></a></li>
                 <li title="Informa em qual fila o coletor irá aguardar">Fila de coletas: 
                 {% if crawler.expected_runtime_category == 'fast' %} 
                     <span class="badge badge-success">Rápida</span>


### PR DESCRIPTION
Adicionando campos de tipo de coletor, descrição do coletor e número da issue referente a coleta. Para testar basta criar um coletor e verificar se os novos campos aparecem na parte de informações básicas. Assim como checar se na tela de detalhes do coletor aparecem as informações, inclusive o link para a issue da coleta.