### PR TITLE
Issue 770v2 - Atualizando versões do jQuery e seu dependente jQuery UI

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -3,14 +3,14 @@
 
 <head>
     <meta charset="utf-8">
-    <script src="https://code.jquery.com/jquery-3.4.1.min.js" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
         integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
         crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
         integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
         crossorigin="anonymous"></script>
-    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
         integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">


### PR DESCRIPTION
Novo envio da "mesma" PR por conflitos de environment.

A issue https://github.com/MPMG-DCC-UFMG/C01/issues/770 inicialmente tratava de duas versões de jQuery rodando, mas na verdade, a chamada da linha 13 em base.html é como se fosse um adendo a biblioteca do jQuery. O jQuery UI é responsável por alguns elementos e interações de user experience, e esta é dependente do core do jQuery, mas não é a mesma coisa.
Pelo o que vi nas discussões citadas na issue, tinham tentado subir a versão do jQuery da 3.4.1 pra 3.5.1 e talvez não tenham subido a versão da UI também, o que pode ter causado algum conflito e algumas coisas pararam de funcionar, então, voltaram atrás deixando o jQuery na versão 3.4.1 que usamos hoje.

Resolvi então subir as versões das duas pras mais atuais e estáveis no momento: jQuery 3.6.0 e jQuery UI 1.13.2, cuidando para que sejam compatíveis, e conforme os testes que realizei no sistema, tudo parece continuar funcionando corretamente.

Para testar, checar o funcionamento de botões, animações, expansões, envios de formulário, etc... e também o log de erros do navegador.
