### PR TITLE
Issue 3875 - Corrige exibição do passo "Executar em iframe"

### DIFF
--- a/main/staticfiles/js/step_block.js
+++ b/main/staticfiles/js/step_block.js
@@ -62,6 +62,8 @@ function init_block(step_list, depth){
     block.turn_to_attribution_step = turn_to_attribution_step
     block.turn_to_new_tab_step = turn_to_new_tab_step
     block.turn_to_close_tab_step = turn_to_close_tab_step
+    block.turn_to_run_in_iframe_step = turn_to_run_in_iframe_step
+    block.turn_to_exit_iframe_step = turn_to_exit_iframe_step
     block.turn_to_if_step = turn_to_if_step
 
 
@@ -562,7 +564,7 @@ function add_open_iframe_button(block) {
     open_iframe_img.style.height = "1.25em"
 
     block.open_iframe_button.onclick = function () {
-        let xpath = load_param_dict(block).xpath;
+        let xpath = block.xpath_input.value;
 
         if (xpath.length == 0) {
             alert('É necessário especificar o XPATH do iframe antes!')
@@ -576,7 +578,11 @@ function add_open_iframe_button(block) {
         }
 
         let host = location.protocol + '//' + location.host;
-        let url_of_iframe_loader = `${host}/iframe/load?url="${base_url}"&xpath="${xpath}"`
+
+        let enc_base_url = encodeURIComponent(base_url)
+        let enc_xpath = encodeURIComponent(xpath)
+
+        let url_of_iframe_loader = `${host}/iframe/load?url=${enc_base_url}&xpath=${enc_xpath}`
 
         window.open(url_of_iframe_loader, '_blank').focus();
     }
@@ -603,57 +609,53 @@ function refresh_step(){
     block.classList.remove("iframe-context-start")
     block.classList.remove("iframe-context-end")
 
-    if(this.value=="Para cada"){
+    if(this.value=="Para cada") {
         block.turn_to_for_step()
-    }else if(this.value=="Enquanto"){
+    } else if(this.value=="Enquanto") {
         block.turn_to_while_step()
-    }else if(this.value=="Se"){
+    } else if(this.value=="Se") {
         block.turn_to_if_step()
-    }else if(this.value=="Atribuição"){
+    } else if(this.value=="Atribuição") {
         block.turn_to_attribution_step()
-    }else if(this.value=="Abrir em nova aba"){
+    } else if(this.value=="Abrir em nova aba") {
         block.turn_to_new_tab_step()
         block.className += " new-tab-context-start"
         execution_context_changed = true
-    }else if(this.value=="Fechar aba"){
+    } else if(this.value=="Fechar aba") {
         block.turn_to_close_tab_step()
         block.className += " new-tab-context-end"
         execution_context_changed = true
-    }
-    else{        
+    } else if (this.value == "Executar em iframe") {
+        block.turn_to_run_in_iframe_step()
+        block.className += " iframe-context-start"
+        execution_context_changed = true;
+    } else if (this.value == "Sair de iframe") {
+        block.turn_to_exit_iframe_step()
+        block.className += " iframe-context-end"
+        execution_context_changed = true;
+    } else {
         block.delete_lines(block.lines.length)
         block.add_line()
-        
+
         for(param of block.step.mandatory_params){
             field_options = block.step.field_options[param]
             block.add_param(param, field_options)
         }
-        
+
         optional_params = Object.keys(block.step.optional_params)
         if(optional_params.length!=0){
             block.init_optional_params_button(block.step)
-        }
-    
-        if (this.value == "Executar em iframe") {
-            block.className += " iframe-context-start"
-            execution_context_changed = true;            
-            add_open_iframe_button(block);
-        }
-
-        else if (this.value == "Sair de iframe") {
-            block.className += " iframe-context-end"
-            execution_context_changed = true;
         }
     }
 
     //add block tooltip depending on type selection
     block.add_block_tooltip();
-    
+
     if (execution_context_changed) {
         let index = get_index_in_parent(block)
         refresh_steps_option_below_index(index)
     }
-    
+
     colorize_contexts()
 }
 
@@ -845,6 +847,37 @@ function turn_to_new_tab_step(){
 }
 
 function turn_to_close_tab_step(){
+    block = find_parent_with_attr_worth(this, "block")
+    block.delete_lines(block.lines.length)
+    block.add_line()
+    block.lines[0].row.full = true
+}
+
+/**
+ * Sets the block to the run in iframe step.
+ * This function is a method of the block.
+ */
+function turn_to_run_in_iframe_step(){
+    block = find_parent_with_attr_worth(this, "block")
+    block.delete_lines(block.lines.length)
+    block.add_line()
+
+    // defines iframe xpath
+    xpath_input_box = document.createElement("DIV")
+    xpath_input_box.className = "col-sm"
+    xpath_input = document.createElement("INPUT")
+    xpath_input.placeholder = "xpath do iframe"
+    xpath_input.className = "form-control row"
+    xpath_input_box.appendChild(xpath_input)
+    block.xpath_input = xpath_input
+
+    block.lines[0].row.appendChild(xpath_input_box)
+    block.lines[0].row.full = true
+
+    add_open_iframe_button(block);
+}
+
+function turn_to_exit_iframe_step(){
     block = find_parent_with_attr_worth(this, "block")
     block.delete_lines(block.lines.length)
     block.add_line()

--- a/main/staticfiles/js/steps.js
+++ b/main/staticfiles/js/steps.js
@@ -223,6 +223,10 @@ function load_steps(json_steps, step_list){
         block.xpath_input.value = json_steps.link_xpath
         args = {}
 
+    }else if(json_steps.step == "executar_em_iframe"){
+        block.xpath_input.value = json_steps.xpath
+        args = {}
+
     }else if(json_steps.step == "elemento_existe_na_pagina"){
       args = json_steps.arguments
       for(let child of json_steps.children){
@@ -352,6 +356,9 @@ function get_step_json_format(block){
         }
     }else if(param_name == "abrir_em_nova_aba"){
         step_dict.link_xpath = block.xpath_input.value
+        step_dict.children = []
+    }else if(param_name == "executar_em_iframe"){
+        step_dict.xpath = block.xpath_input.value
         step_dict.children = []
     }else{
         step_dict.arguments = load_param_dict(block)

--- a/src/step-by-step/step_crawler/code_generator.py
+++ b/src/step-by-step/step_crawler/code_generator.py
@@ -153,7 +153,7 @@ def generate_screenshot(child, module):
 
 
 def generate_executar_em_iframe(child, module):
-    xpath = child['arguments']['xpath']
+    xpath = child['xpath']
     code = "\n"
     code += child['depth'] * '    ' + "### Início: Passando o contexto de execução para iframe ###\n"
     code += child['depth'] * '    ' + f'el_locator_xpath = {xpath}\n'

--- a/tests/test_step_by_step/code_generator_test.py
+++ b/tests/test_step_by_step/code_generator_test.py
@@ -155,6 +155,34 @@ class TestExtractInfo(unittest.TestCase):
         expected_result += "        imprime(texto = \"teste\")\n"
         self.assertEqual(expected_result, result)
 
+    def test_generate_executar_em_iframe(self):
+        with open("tests/test_step_by_step/examples/recipe_examples.json") as file:
+            recipe_examples = json.load(file)
+
+        # Getting in and out of an iframe
+        result = cg.generate_body(atom.extend(
+            recipe_examples['iframe_exec']['recipe'])[0], ff, False)
+
+        expected_result = "\n"
+        expected_result += "    ### Início: Passando o contexto de execução para iframe ###\n"
+        expected_result += '    el_locator_xpath = "teste"\n'
+        expected_result += '    el_locator = missing_arguments["pagina"].locator(f"xpath={el_locator_xpath}")\n'
+        expected_result += '    await el_locator.wait_for()\n'
+        expected_result += '    el_handler = await el_locator.first.element_handle()\n'
+        expected_result += '    iframe_stack.append(await el_handler.content_frame())\n'
+        expected_result += '    missing_arguments["pagina"] = iframe_stack[-1]\n'
+        expected_result += "    ### Fim: Passando o contexto de execução para iframe ###\n"
+        expected_result += "\n"
+        expected_result += "    ### Início: Saindo do contexto de iframe ###\n"
+        expected_result += '    iframe_stack.pop()\n'
+        expected_result += '    if not iframe_stack:\n'
+        expected_result += '        missing_arguments["pagina"] = page\n'
+        expected_result += '    else:\n'
+        expected_result += '        missing_arguments["pagina"] = iframe_stack[-1]\n'
+        expected_result += "    ### Fim: Saindo do contexto de iframe ###\n\n"
+
+        self.assertEqual(expected_result, result)
+
     # def test_generate_code(self):
     #     with open("tests/test_step_by_step/examples/recipe_examples.json") as file:
     #         recipe_examples = json.load(file)

--- a/tests/test_step_by_step/examples/recipe_examples.json
+++ b/tests/test_step_by_step/examples/recipe_examples.json
@@ -411,5 +411,25 @@
                 }
             ]
         }
+    },
+    "iframe_exec": {
+        "description": "Getting in and out of an iframe element",
+        "recipe": {
+            "step": "root",
+            "depth": 0,
+            "children": [
+                {
+                    "step": "executar_em_iframe",
+                    "xpath": "\"teste\"",
+                    "depth": 1,
+                    "children": []
+                },
+                {
+                    "step": "sair_de_iframe",
+                    "depth": 1,
+                    "children": []
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
Campo de XPath no passo de "Executar em iframe" volta a ser exibido. Ainda temos problemas no botão de visualizar o conteúdo do iframe na interface (ver #4320 e #5280) mas isso não impede a execução das coletas, sendo apenas uma questão de facilidade para o usuário. O problema relatado pela issue foi resolvido e as coletas bloqueadas poderão ser feitas.

Closes #3875.