### PR TITLE
Issue 5291 - Resolve problemas em exemplo de Itabirito

### DIFF
--- a/docker/spider_manager/Dockerfile
+++ b/docker/spider_manager/Dockerfile
@@ -7,7 +7,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get autoremove \
     && apt-get install libffi-dev tzdata ffmpeg libsm6 libnss3 libxss1 \
     libasound2 libatk-bridge2.0-0 libgtk-3-0 libxext6 python3.7 python3-pip \
-    libxml2-dev libxslt-dev -y && apt-get autoclean && pip install -U pip
+    libxml2-dev libxslt-dev libssl-dev -y && apt-get autoclean && pip install \
+    -U pip
 
 # # Install dependencies
 # RUN apt-get update && apt-get install -y \

--- a/spider_manager/requirements.txt
+++ b/spider_manager/requirements.txt
@@ -4,11 +4,11 @@
 ../captcha_solver/
 ../cssify/
 ../scutils/
-attrs==18.1.0  # Updated from 17.2.0'
+attrs>=19.2.0 # 18.1.0  # Updated from 17.2.0'
 cchardet==2.1.7
 cffi==1.12.3  # Updated from 1.10.0
 ConcurrentLogHandler==0.9.1
-cryptography==2.3
+cryptography==38.0.0 # 2.3
 cssselect==1.0.3  # Updated from 1.0.1
 enum34==1.1.6
 funcsigs==1.0.2
@@ -26,23 +26,23 @@ pyasn1==0.4.3  # Updated from 0.3.2
 pyasn1-modules==0.2.1  # Updated from 0.0.11
 pycparser==2.18
 PyDispatcher==2.0.5
-pyOpenSSL==18.0.0  # Updated from 17.2.0
+pyOpenSSL==22.1.0 # 18.0.0  # Updated from 17.2.0
 python-json-logger==0.1.8
 PyYAML==6.0
 queuelib==1.5.0  # Updated from 1.4.2
-redis>=3.0  # Updated from 2.10.5
+redis>=4.0 # 3.0  # Updated from 2.10.5
 requests
 requests-file==1.4.3  # Updated from 1.4.2
 retrying==1.3.3
-Scrapy==2.0.1  # Updated from 1.4.0
-service-identity==17.0.0
+Scrapy==2.6.3 # 2.0.1 # Updated from 1.4.0
+service-identity==21.1.0 # 17.0.0
 six==1.11.0  # Updated from 1.10.0
 testfixtures==6.0.2  # Updated from 5.1.1
 tldextract==2.2.0  # Updated from 2.1.0
-Twisted==18.9.0  # Updated from 17.5.0
-ujson==1.35
+Twisted==22.8.0 # 18.9.0  # Updated from 17.5.0
+ujson==5.5.0 # 1.35
 w3lib==1.19.0  # Updated from 1.18.0
 zope.interface==5.0.0  # Updated from 4.4.2
-playwright>=1.8.0a1
-scrapy-playwright==0.0.9 # Playwright interface
+playwright>=1.15
+scrapy-playwright==0.0.21 # Playwright interface
 python-magic

--- a/spider_manager/src/crawling/items.py
+++ b/spider_manager/src/crawling/items.py
@@ -22,6 +22,7 @@ class RawResponseItem(Item):
     crawler_id = Field()
     instance_id = Field()
     crawled_at_date = Field()
+    cookies = Field()
     files_found = Field()
     images_found = Field()
     attrs = Field()

--- a/spider_manager/src/crawling/pipelines.py
+++ b/spider_manager/src/crawling/pipelines.py
@@ -193,6 +193,8 @@ class KafkaPipeline(object):
 
                 elif 'utf-8' != encoding:
                     datum['body'] = datum['body'].decode(datum['encoding'])
+                elif isinstance(datum['body'], bytes):
+                    datum['body'] = datum['body'].decode(datum['encoding'])
 
                 message = ujson.dumps(datum, sort_keys=True)
             except:

--- a/spider_manager/src/crawling/spiders/base_spider.py
+++ b/spider_manager/src/crawling/spiders/base_spider.py
@@ -66,6 +66,9 @@ class BaseSpider(RedisSpider):
 
     def filetypes_from_mimetype(self, mimetype: str) -> str:
         """Detects the file type using its mimetype"""
+        if mimetype is None:
+            return [""]
+
         extensions = mimetypes.guess_all_extensions(mimetype) 
         if len(extensions) > 0:
             return [ext.replace(".", "") for ext in extensions]

--- a/spider_manager/src/crawling/spiders/static_page.py
+++ b/spider_manager/src/crawling/spiders/static_page.py
@@ -120,7 +120,7 @@ class StaticPageSpider(BaseSpider):
         )
 
         urls_found = set(link.url for link in links_extractor.extract_links(response))
-        exclude_html_and_php_regex_pattern = r"(.*\.[a-z]{3,4}$)(.*(?<!\.html)$)(.*(?<!\.php)$)"
+        exclude_html_and_php_regex_pattern = r"(.*(?<!\.html)$)(.*(?<!\.php)$)"
         urls_found = self.filter_urls_by_regex(urls_found, exclude_html_and_php_regex_pattern)
 
         broken_urls = urls_found
@@ -211,8 +211,15 @@ class StaticPageSpider(BaseSpider):
             item["instance_id"] = self.config["instance_id"]
             item["crawled_at_date"] = str(datetime.datetime.today())
 
-            item["files_found"] = files_found
-            item["images_found"] = images_found
+            cookies = response.headers.getlist('Set-Cookie')[0].decode('utf-8')\
+                .split(";")
+            item["cookies"] = {
+                c.split("=")[0]: c.split("=")[1]
+                for c in cookies if "=" in c
+            }
+
+            item["files_found"] = list(files_found)
+            item["images_found"] = list(images_found)
             item["attrs"] = response.meta["attrs"]
             item["attrs"]["steps"] = self.config["steps"]
             item["attrs"]["steps_req_num"] = idx

--- a/writer/src/download_request.py
+++ b/writer/src/download_request.py
@@ -26,7 +26,8 @@ class DownloadRequest:
                 filename: str = '',
                 filetype: str = '',
                 crawled_at_date: str = '',
-                attrs: dict = {}) -> None:
+                attrs: dict = {},
+                cookies: dict = {}) -> None:
 
         self.attrs = attrs,
         self.url = url
@@ -39,6 +40,7 @@ class DownloadRequest:
             str(instance_id), 'data', 'files', self.filename)
         self.data_path = data_path
         self.crawled_at_date = crawled_at_date
+        self.cookies = cookies
 
 
     def __generate_filename(self) -> str:
@@ -96,7 +98,8 @@ class DownloadRequest:
 
         attempt = 0
         while attempt < MAX_ATTEMPTS:
-            with requests.get(self.url, stream=True, allow_redirects=True, headers=settings.REQUEST_HEADERS) as req:
+            with requests.get(self.url, stream=True, allow_redirects=True,
+                headers=settings.REQUEST_HEADERS, cookies=self.cookies) as req:
                 if req.status_code != 200:
                     attempt += 1
                     time.sleep(attempt * INTERVAL_BETWEEN_ATTEMPTS)
@@ -128,6 +131,7 @@ class DownloadRequest:
             'type': self.filetype,
             'attrs': self.attrs,
             'crawled_at_date': self.crawled_at_date,
+            'cookies': self.cookies,
             'extracted_files': [
 
             ]

--- a/writer/src/file_downloader.py
+++ b/writer/src/file_downloader.py
@@ -114,6 +114,7 @@ class FileDownloader:
                 'referer': referer,
                 'filetype': '',
                 'filename': '',
+                'cookies': crawled_data['cookies'],
                 "attrs": crawled_data['attrs'],
                 'data_path': data_path,
                 'crawled_at_date': ''


### PR DESCRIPTION
Essa PR faz as seguintes alterações:

- Atualiza algumas dependências do `spider_manager`, fazendo as alterações necessárias no código
- No JSON carregado no Kafka:
  - Converte dados binários pra texto (causavam erro ao serializar o JSON)
  - Remove dados do Playwright (causavam recursão infinita ao serializar o JSON, e além disso o Playwright não é usado em requisições disparadas pelas spiders, só na requisição inicial)
- Resolve bug na detecção de extensão quando o mimetype é `None`
- Torna filtro de arquivos mais flexível (não exige mais extensão na URL, a issue #7089 trata de mais problemas nesse ponto)
- Passa os cookies recebidos na resposta pro módulo `writer` ao baixar arquivos, permitindo manutenção da sessão

Dois detalhes importantes ao testar o coletor incluído na issue:
- Na configuração da coleta dinâmica faltou um passo "Salvar página" no fim do procedimento. O caso que deve testado deve ter um passo "Salvar página" no final.
- Como as URLs dos arquivos não tem extensão (as URLs que levam a arquivos PDF não tem extensão `.pdf`, por exemplo) o filtro de arquivos elimina essas páginas. Dessa forma é importante deixar o campo de extensões permitidas vazio. Com essa alteração e as modificações dessa PR, a coleta funciona corretamente.

Closes #5291.