### PR TITLE
Issue 5917 - Erro ao remover volume estático em pasta não-padrão

### DIFF
--- a/docker-compose-cleanup.yml
+++ b/docker-compose-cleanup.yml
@@ -1,0 +1,4 @@
+version: '3.7'
+
+volumes:
+    static_volume:

--- a/run.py
+++ b/run.py
@@ -13,7 +13,7 @@ myenv = {
     "ENVFILENAME": str(args["debug"]),
 }
 subprocess.run("docker-compose down".split(), env=myenv)
-subprocess.run("docker volume rm c01_static_volume".split())
+subprocess.run("docker-compose -f docker-compose-cleanup.yml down -v".split(), env=myenv)
 subprocess.run("docker-compose build --parallel".split(), env=myenv)
 subprocess.run("docker-compose up -d".split(), env=myenv)
 time.sleep(10)


### PR DESCRIPTION
Adiciona arquivo `docker-compose-cleanup.yml` que lista os volumes que devem removidos ao executar o `run.py`. A limpeza foi implementada dessa forma para que funcione independentemente do nome da pasta que contem o sistema.

Closes #5917.