### PR TITLE
Issue 7294 - Remove o componente Scrapy-Playwright do código

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
         build:
             context: .
             dockerfile: ./docker/spider_manager/Dockerfile
+        init: true
         env_file:
             - ./docker/config/main.env
         volumes:

--- a/spider_manager/requirements.txt
+++ b/spider_manager/requirements.txt
@@ -43,6 +43,5 @@ Twisted==22.8.0 # 18.9.0  # Updated from 17.5.0
 ujson==5.5.0 # 1.35
 w3lib==1.19.0  # Updated from 1.18.0
 zope.interface==5.0.0  # Updated from 4.4.2
-playwright>=1.15
-scrapy-playwright==0.0.21 # Playwright interface
+playwright==1.27
 python-magic

--- a/spider_manager/src/crawling/decoding_utils.py
+++ b/spider_manager/src/crawling/decoding_utils.py
@@ -1,0 +1,21 @@
+# Functions dealing with byte-to-str conversions
+
+def decode_binary_entry(data):
+    if type(data) == list:
+        return list(map(decode_binary_entry, data))
+    elif type(data) == dict:
+        result = {}
+
+        for entry_key in data:
+            decoded_key = entry_key
+
+            if type(entry_key) == bytes:
+                decoded_key = entry_key.decode('utf-8')
+
+            result[decoded_key] = decode_binary_entry(data[entry_key])
+
+        return result
+    elif type(data) == bytes:
+        return data.decode('utf-8')
+    else:
+        return data

--- a/spider_manager/src/crawling/distributed_scheduler.py
+++ b/spider_manager/src/crawling/distributed_scheduler.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from crawling_utils import notify_new_page_found, notify_page_duplicated_found
 from crawling.redis_global_page_per_domain_filter import \
     RFGlobalPagePerDomainFilter
+from crawling.decoding_utils import decode_binary_entry
 from crawling.redis_dupefilter import RFPDupeFilter
 from crawling.redis_domain_max_page_filter import RFDomainMaxPageFilter
 from six import string_types
@@ -500,27 +501,7 @@ class DistributedScheduler(object):
                     if "playwright_security_details" in req_dict["meta"]:
                         del req_dict["meta"]["playwright_security_details"]
 
-                def decode_entry(data):
-                    if type(data) == list:
-                        return list(map(decode_entry, data))
-                    elif type(data) == dict:
-                        result = {}
-
-                        for entry_key in data:
-                            decoded_key = entry_key
-
-                            if type(entry_key) == bytes:
-                                decoded_key = entry_key.decode('utf-8')
-
-                            result[decoded_key] = decode_entry(data[entry_key])
-
-                        return result
-                    elif type(data) == bytes:
-                        return data.decode('utf-8')
-                    else:
-                        return data
-
-                clean_dict = decode_entry(req_dict.copy())
+                clean_dict = decode_binary_entry(req_dict.copy())
 
                 # we may already have the queue in memory
                 if key in self.queue_keys:

--- a/spider_manager/src/executor.py
+++ b/spider_manager/src/executor.py
@@ -15,7 +15,6 @@ import ujson
 from kafka import KafkaProducer
 from scrapy.crawler import CrawlerProcess
 from scrapy.spiders import Spider
-from scrapy.utils.reactor import install_reactor
 
 from crawling.spiders.static_page import StaticPageSpider
 from kafka_logger import KafkaLogger
@@ -85,12 +84,6 @@ class Executor:
 
         if config.get("dynamic_processing", False):
             base_config["TWISTED_REACTOR"] = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-
-            base_config["DOWNLOAD_HANDLERS"] = {
-                "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
-                "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
-            }
-
             base_config["DATA_PATH"] = config["data_path"]
             base_config["OUTPUT_FOLDER"] = settings.OUTPUT_FOLDER
             base_config["CRAWLER_ID"] = config["crawler_id"]
@@ -98,24 +91,6 @@ class Executor:
 
             base_config["DYNAMIC_PROCESSING"] = True
             base_config["DYNAMIC_PROCESSING_STEPS"] = ujson.loads(config["steps"])
-
-            instance_path = os.path.join(settings.OUTPUT_FOLDER, config["data_path"], str(config["instance_id"]))
-            download_path = os.path.join(instance_path, 'data', 'files', 'temp')
-            base_config["PLAYWRIGHT_LAUNCH_OPTIONS"] = {
-                'downloads_path': download_path,
-                # uncommenting the following line causes some collector
-                # instances to fail
-                # 'args': ['--no-sandbox']
-            }
-            base_config["PLAYWRIGHT_CONTEXTS"] = {
-                'default': {
-                    'viewport': {
-                        'width': config["browser_resolution_width"],
-                        'height': config["browser_resolution_height"]
-                    }
-                }
-            }
-            base_config["PLAYWRIGHT_BROWSER_TYPE"] = config["browser_type"]
 
         # Antiblock middlewares
         if config.get("antiblock_ip_rotation_type", "") == "tor":
@@ -172,7 +147,6 @@ class Executor:
         base_settings = self.__get_spider_base_settings(config)
         self.__parse_config(base_settings)
 
-        install_reactor('twisted.internet.asyncioreactor.AsyncioSelectorReactor')
         process = CrawlerProcess(settings=base_settings)
 
         process.crawl(StaticPageSpider,


### PR DESCRIPTION
O código passa a utilizar o Playwright diretamente sem o intermédio da biblioteca `scrapy_playwright`. Também foi adicionado um processo de init (pid 1) padrão do Docker ao container `spider_manager` para lidar adequadamente com processos zumbis.

Closes #7294.