### PR TITLE
Issue 7758 - Inconsistência no passo digite

### DIFF
--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -198,9 +198,6 @@ async def retorna_pagina(pagina):
 async def digite(pagina, xpath, texto):
     el_locator = pagina.locator(f'xpath={xpath}')
     await el_locator.evaluate(f'el => el.value = "{texto.strip()}"')
-    # await el_locator.evaluate('el => el.value = ""')
-    # await el_locator.type(texto)
-
 
 @step("Objeto")
 async def objeto(pagina, objeto):

--- a/src/step-by-step/step_crawler/functions_file.py
+++ b/src/step-by-step/step_crawler/functions_file.py
@@ -197,8 +197,9 @@ async def retorna_pagina(pagina):
 @step("Digitar em")
 async def digite(pagina, xpath, texto):
     el_locator = pagina.locator(f'xpath={xpath}')
-    await el_locator.evaluate('el => el.value = ""')
-    await el_locator.type(texto)
+    await el_locator.evaluate(f'el => el.value = "{texto.strip()}"')
+    # await el_locator.evaluate('el => el.value = ""')
+    # await el_locator.type(texto)
 
 
 @step("Objeto")


### PR DESCRIPTION
Para as coletas referidas na issue #7758, as alterações feitas mostraram-se eficazes na resolução dos problemas.

Porém, há configurações de coletas, como 
[[realização-f01]_-_coleta_de_concursos_publicos_-__de_andradas.txt](https://github.com/MPMG-DCC-UFMG/C01/files/10022558/realizacao-f01._-_coleta_de_concursos_publicos_-__de_andradas.txt) (trocar extensão txt para json), em que o passo `clique` é substituído pelo `\n`, ao final do texto ao ser digitado. 

Tais coletores foram considerados com mal-configurados, uma vez que o esperado é que o comportamento de `submit` seja realizado por algum passo como o `clique`, ao invés de se usar `\n` ao final do texto do passo `digite`.

Logo, ao se aprovar essa PR, coletores como o citado precisarão ser atualizados ou mesmo se tornarão inválidos.

Closes #7758   