### PR TITLE
Issue 4798 - Post mortem DEBUG - Trace Viewer e Gravar Vídeo

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -62,7 +62,6 @@ class CrawlRequestForm(forms.ModelForm):
             'dynamic_processing',
 
             'create_trace_enabled',
-            'headful_enabled',
             'video_recording_enabled',
 
             'browser_type',
@@ -444,11 +443,7 @@ class RawCrawlRequestForm(CrawlRequestForm):
         label="Criar arquivo trace.zip",
         help_text="Gera o arquivo 'trace.zip' para depuração do coletor com a ferramenta Trace Viewer"
     )
-    headful_enabled = forms.BooleanField(
-        required=False,
-        label="Ativar modo Headful",
-        help_text="Executa o browser em modo Headful."
-    )
+
     video_recording_enabled = forms.BooleanField(
         required=False,
         label="Gravar vídeo do coletor",

--- a/main/forms.py
+++ b/main/forms.py
@@ -1,5 +1,3 @@
-from email.policy import default
-from cv2 import FarnebackOpticalFlow
 from django import forms
 from .models import CrawlRequest, ParameterHandler, ResponseHandler
 from django.core.exceptions import ValidationError

--- a/main/forms.py
+++ b/main/forms.py
@@ -1,3 +1,4 @@
+from email.policy import default
 from cv2 import FarnebackOpticalFlow
 from django import forms
 from .models import CrawlRequest, ParameterHandler, ResponseHandler
@@ -59,6 +60,11 @@ class CrawlRequestForm(forms.ModelForm):
             'img_xpath',
             'sound_xpath',
             'dynamic_processing',
+
+            'create_trace_enabled',
+            'headful_enabled',
+            'video_recording_enabled',
+
             'browser_type',
             'skip_iter_errors',
             'browser_resolution_width',
@@ -431,6 +437,22 @@ class RawCrawlRequestForm(CrawlRequestForm):
 
     skip_iter_errors = forms.BooleanField(
         required=False, label="Pular iterações com erro"
+    )
+    
+    create_trace_enabled = forms.BooleanField(
+        required=False,
+        label="Criar arquivo trace.zip",
+        help_text="Gera o arquivo 'trace.zip' para depuração do coletor com a ferramenta Trace Viewer"
+    )
+    headful_enabled = forms.BooleanField(
+        required=False,
+        label="Ativar modo Headful",
+        help_text="Executa o browser em modo Headful."
+    )
+    video_recording_enabled = forms.BooleanField(
+        required=False,
+        label="Gravar vídeo do coletor",
+        help_text="Gera um vídeo da execução do coletor."
     )
 
     explore_links = forms.BooleanField(required=False, label="Explorar links")

--- a/main/models.py
+++ b/main/models.py
@@ -1,5 +1,4 @@
 import datetime
-from email.policy import default
 from typing import List, Union
 
 from crawler_manager.constants import *

--- a/main/models.py
+++ b/main/models.py
@@ -181,7 +181,6 @@ class CrawlRequest(TimeStamped):
 
     # Debug Mode
     create_trace_enabled = models.BooleanField(default=False)
-    headful_enabled = models.BooleanField(default=False)
     video_recording_enabled = models.BooleanField(default=False)
 
     # DETAILS #################################################################

--- a/main/models.py
+++ b/main/models.py
@@ -1,4 +1,5 @@
 import datetime
+from email.policy import default
 from typing import List, Union
 
 from crawler_manager.constants import *
@@ -178,6 +179,10 @@ class CrawlRequest(TimeStamped):
     browser_resolution_width = models.IntegerField(blank=True, null=True)
     browser_resolution_height = models.IntegerField(blank=True, null=True)
 
+    # Debug Mode
+    create_trace_enabled = models.BooleanField(default=False)
+    headful_enabled = models.BooleanField(default=False)
+    video_recording_enabled = models.BooleanField(default=False)
 
     # DETAILS #################################################################
     explore_links = models.BooleanField(blank=True, null=True)

--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -176,7 +176,7 @@ table.dataTable thead .sorting_desc_disabled:before {
     background-color: #E8F6EF;
 }
 
-#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled, #dynamic-processing-trace-enabled.disabled, #dynamic-processing-headful-enabled.disabled, #dynamic-processing-video-recording-enabled.disabled {
+#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled {
     opacity: .5;
     pointer-events: none;
 }

--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -176,7 +176,7 @@ table.dataTable thead .sorting_desc_disabled:before {
     background-color: #E8F6EF;
 }
 
-#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled {
+#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled, #dynamic-processing-headful-enabled {
     opacity: .5;
     pointer-events: none;
 }

--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -176,7 +176,7 @@ table.dataTable thead .sorting_desc_disabled:before {
     background-color: #E8F6EF;
 }
 
-#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled {
+#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled, #dynamic-processing-trace-enabled.disabled, #dynamic-processing-headful-enabled.disabled, #dynamic-processing-video-recording-enabled.disabled {
     opacity: .5;
     pointer-events: none;
 }

--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -176,7 +176,7 @@ table.dataTable thead .sorting_desc_disabled:before {
     background-color: #E8F6EF;
 }
 
-#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled, #dynamic-processing-headful-enabled {
+#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled {
     opacity: .5;
     pointer-events: none;
 }

--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -176,7 +176,7 @@ table.dataTable thead .sorting_desc_disabled:before {
     background-color: #E8F6EF;
 }
 
-#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled {
+#dynamic-processing-item-wrap.disabled, #dynamic-processing-skip-errors.disabled, #dynamic-processing-browser-type.disabled, #dynamic-processing-resolution.disabled, #dynamic-processing-debug-mode.disabled {
     opacity: .5;
     pointer-events: none;
 }

--- a/main/staticfiles/js/create_crawler.js
+++ b/main/staticfiles/js/create_crawler.js
@@ -413,8 +413,7 @@ function detailDynamicProcessing() {
     dynamic_processing_skip_errors = document.getElementById("dynamic-processing-skip-errors")
     dynamic_processing_resolution = document.getElementById("dynamic-processing-resolution")
     dynamic_processing_browser_type = document.getElementById("dynamic-processing-browser-type")
-    dynamic_processing_trace_enabled = document.getElementById("dynamic-processing-trace-enabled")
-    dynamic_processing_video_recording_enabled = document.getElementById("dynamic-processing-video-recording-enabled")
+    dynamic_processing_debug_mode = document.getElementById("dynamic-processing-debug-mode")
 
     if(getCheckboxState("id_dynamic_processing")){
         dynamic_processing_check.classList.remove("disabled")
@@ -422,17 +421,15 @@ function detailDynamicProcessing() {
         dynamic_processing_skip_errors.classList.remove("disabled")
         dynamic_processing_resolution.classList.remove("disabled")
         dynamic_processing_browser_type.classList.remove("disabled")
-        dynamic_processing_trace_enabled.classList.remove("disabled")
-        dynamic_processing_video_recording_enabled.classList.remove("disabled")
-
+        dynamic_processing_debug_mode.classList.remove("disabled")
     }else{
         dynamic_processing_check.classList.add("disabled")
         dynamic_processing_block.classList.add("disabled")
         dynamic_processing_skip_errors.classList.add("disabled")
         dynamic_processing_resolution.classList.add("disabled")
         dynamic_processing_browser_type.classList.add("disabled")
-        dynamic_processing_trace_enabled.classList.add("disabled")
-        dynamic_processing_video_recording_enabled.classList.add("disabled")    }
+        dynamic_processing_debug_mode.classList.add("disabled")
+    }
 }
 
 function detailCaptcha() {

--- a/main/staticfiles/js/create_crawler.js
+++ b/main/staticfiles/js/create_crawler.js
@@ -414,7 +414,6 @@ function detailDynamicProcessing() {
     dynamic_processing_resolution = document.getElementById("dynamic-processing-resolution")
     dynamic_processing_browser_type = document.getElementById("dynamic-processing-browser-type")
     dynamic_processing_trace_enabled = document.getElementById("dynamic-processing-trace-enabled")
-    dynamic_processing_headful_enabled = document.getElementById("dynamic-processing-headful-enabled")
     dynamic_processing_video_recording_enabled = document.getElementById("dynamic-processing-video-recording-enabled")
 
     if(getCheckboxState("id_dynamic_processing")){
@@ -424,7 +423,6 @@ function detailDynamicProcessing() {
         dynamic_processing_resolution.classList.remove("disabled")
         dynamic_processing_browser_type.classList.remove("disabled")
         dynamic_processing_trace_enabled.classList.remove("disabled")
-        dynamic_processing_headful_enabled.classList.remove("disabled")
         dynamic_processing_video_recording_enabled.classList.remove("disabled")
 
     }else{
@@ -434,7 +432,6 @@ function detailDynamicProcessing() {
         dynamic_processing_resolution.classList.add("disabled")
         dynamic_processing_browser_type.classList.add("disabled")
         dynamic_processing_trace_enabled.classList.add("disabled")
-        dynamic_processing_headful_enabled.classList.add("disabled")
         dynamic_processing_video_recording_enabled.classList.add("disabled")    }
 }
 

--- a/main/staticfiles/js/create_crawler.js
+++ b/main/staticfiles/js/create_crawler.js
@@ -413,6 +413,9 @@ function detailDynamicProcessing() {
     dynamic_processing_skip_errors = document.getElementById("dynamic-processing-skip-errors")
     dynamic_processing_resolution = document.getElementById("dynamic-processing-resolution")
     dynamic_processing_browser_type = document.getElementById("dynamic-processing-browser-type")
+    dynamic_processing_trace_enabled = document.getElementById("dynamic-processing-trace-enabled")
+    dynamic_processing_headful_enabled = document.getElementById("dynamic-processing-headful-enabled")
+    dynamic_processing_video_recording_enabled = document.getElementById("dynamic-processing-video-recording-enabled")
 
     if(getCheckboxState("id_dynamic_processing")){
         dynamic_processing_check.classList.remove("disabled")
@@ -420,13 +423,19 @@ function detailDynamicProcessing() {
         dynamic_processing_skip_errors.classList.remove("disabled")
         dynamic_processing_resolution.classList.remove("disabled")
         dynamic_processing_browser_type.classList.remove("disabled")
+        dynamic_processing_trace_enabled.classList.remove("disabled")
+        dynamic_processing_headful_enabled.classList.remove("disabled")
+        dynamic_processing_video_recording_enabled.classList.remove("disabled")
+
     }else{
         dynamic_processing_check.classList.add("disabled")
         dynamic_processing_block.classList.add("disabled")
         dynamic_processing_skip_errors.classList.add("disabled")
         dynamic_processing_resolution.classList.add("disabled")
         dynamic_processing_browser_type.classList.add("disabled")
-    }
+        dynamic_processing_trace_enabled.classList.add("disabled")
+        dynamic_processing_headful_enabled.classList.add("disabled")
+        dynamic_processing_video_recording_enabled.classList.add("disabled")    }
 }
 
 function detailCaptcha() {
@@ -682,3 +691,4 @@ function parseSettings(e) {
 
     reader.readAsText(file);
 }
+

--- a/main/staticfiles/js/details.js
+++ b/main/staticfiles/js/details.js
@@ -184,3 +184,8 @@ function exit_crawler_queue(queue_item_id) {
         }
     });
 }
+
+// Initiates all popovers on the page
+$(function () {
+    $('[data-toggle="popover"]').popover()
+})

--- a/main/templates/main/_create_06_dynamic.html
+++ b/main/templates/main/_create_06_dynamic.html
@@ -45,6 +45,4 @@
     <div id="dynamic-processing-item-wrap" style="padding:20px;" class="hidden">
         {{ form.steps | as_crispy_field }}
     </div>
-
-
 </div>

--- a/main/templates/main/_create_06_dynamic.html
+++ b/main/templates/main/_create_06_dynamic.html
@@ -43,10 +43,6 @@
             <div id="dynamic-processing-video-recording_enabled" class="">
                 {{ form.video_recording_enabled | as_crispy_field}}
             </div>
-            <div id="dynamic-processing-headful-enabled" class="">
-                {{ form.headful_enabled | as_crispy_field}}
-                <p class="small">Funcionalidade indisponível no momento.</p>
-            </div>
         </div>
     </div>
 

--- a/main/templates/main/_create_06_dynamic.html
+++ b/main/templates/main/_create_06_dynamic.html
@@ -40,11 +40,12 @@
             <div id="dynamic-processing-trace-enabled" class="">
                 {{ form.create_trace_enabled | as_crispy_field}}
             </div>
-            <div id="dynamic-processing-headful-enabled" class="">
-                {{ form.headful_enabled | as_crispy_field}}
-            </div>
             <div id="dynamic-processing-video-recording_enabled" class="">
                 {{ form.video_recording_enabled | as_crispy_field}}
+            </div>
+            <div id="dynamic-processing-headful-enabled" class="">
+                {{ form.headful_enabled | as_crispy_field}}
+                <p class="small">Funcionalidade indisponível no momento.</p>
             </div>
         </div>
     </div>

--- a/main/templates/main/_create_06_dynamic.html
+++ b/main/templates/main/_create_06_dynamic.html
@@ -34,19 +34,20 @@
     </div>
     <div id="dynamic-processing-item-wrap" style="padding:20px;" class="hidden">
         {{ form.steps | as_crispy_field }}
+        <div id="dynamic-processing-debug-mode" style="padding: 20px; border-top: 1px">
+            Modo Debug
+            <p class="small">Ferramentas de depuração de coletores que utilizam processamento dinâmico</p>
+            <div id="dynamic-processing-trace-enabled" class="">
+                {{ form.create_trace_enabled | as_crispy_field}}
+            </div>
+            <div id="dynamic-processing-headful-enabled" class="">
+                {{ form.headful_enabled | as_crispy_field}}
+            </div>
+            <div id="dynamic-processing-video-recording_enabled" class="">
+                {{ form.video_recording_enabled | as_crispy_field}}
+            </div>
+        </div>
     </div>
-    <div id="dynamic-processing-debug-mode" style="padding: 20px; border-top: 1px">
-        Modo Debug
-        <p class="small">Ferramentas de depuração de coletores que utilizam processamento dinâmico</p>
-        <div id="dynamic-processing-trace-enabled" class="">
-            {{ form.create_trace_enabled | as_crispy_field}}
-        </div>
-        <div id="dynamic-processing-headful-enabled" class="">
-            {{ form.headful_enabled | as_crispy_field}}
-        </div>
-        <div id="dynamic-processing-video-recording_enabled" class="">
-            {{ form.video_recording_enabled | as_crispy_field}}
-        </div>
-    </div>
+
 
 </div>

--- a/main/templates/main/_create_06_dynamic.html
+++ b/main/templates/main/_create_06_dynamic.html
@@ -32,18 +32,18 @@
     <div id="dynamic-processing-skip-errors" class="hidden">
         {{ form.skip_iter_errors | as_crispy_field}}
     </div>
+    <div id="dynamic-processing-debug-mode" class="hidden">
+        Modo Debug
+        <p class="small">Ferramentas de depuração de coletores que utilizam processamento dinâmico</p>
+        <div id="dynamic-processing-trace-enabled" class="">
+            {{ form.create_trace_enabled | as_crispy_field}}
+        </div>
+        <div id="dynamic-processing-video-recording_enabled" class="">
+            {{ form.video_recording_enabled | as_crispy_field}}
+        </div>
+    </div>
     <div id="dynamic-processing-item-wrap" style="padding:20px;" class="hidden">
         {{ form.steps | as_crispy_field }}
-        <div id="dynamic-processing-debug-mode" style="padding: 20px; border-top: 1px">
-            Modo Debug
-            <p class="small">Ferramentas de depuração de coletores que utilizam processamento dinâmico</p>
-            <div id="dynamic-processing-trace-enabled" class="">
-                {{ form.create_trace_enabled | as_crispy_field}}
-            </div>
-            <div id="dynamic-processing-video-recording_enabled" class="">
-                {{ form.video_recording_enabled | as_crispy_field}}
-            </div>
-        </div>
     </div>
 
 

--- a/main/templates/main/_create_06_dynamic.html
+++ b/main/templates/main/_create_06_dynamic.html
@@ -35,4 +35,18 @@
     <div id="dynamic-processing-item-wrap" style="padding:20px;" class="hidden">
         {{ form.steps | as_crispy_field }}
     </div>
+    <div id="dynamic-processing-debug-mode" style="padding: 20px; border-top: 1px">
+        Modo Debug
+        <p class="small">Ferramentas de depuração de coletores que utilizam processamento dinâmico</p>
+        <div id="dynamic-processing-trace-enabled" class="">
+            {{ form.create_trace_enabled | as_crispy_field}}
+        </div>
+        <div id="dynamic-processing-headful-enabled" class="">
+            {{ form.headful_enabled | as_crispy_field}}
+        </div>
+        <div id="dynamic-processing-video-recording_enabled" class="">
+            {{ form.video_recording_enabled | as_crispy_field}}
+        </div>
+    </div>
+
 </div>

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -108,10 +108,10 @@ Crawler "{{ crawler.source_name }}"
                         <td>{{instance.data_size_readable}}</td>
                         {% if crawler.dynamic_processing %}
                         <td><button type="button" class="btn btn-primary" onclick="displayScreenshotModal({{instance.instance_id}})">Visualizar</button></td>
-                        {% endif %}
                         <td><a class="btn btn-primary" href="{% url 'export_config' instance.instance_id%}">Baixar</a></td>
                         <td><a class="btn btn-primary" href="{% url 'export_trace' instance.instance_id%}">Baixar</a></td>
-                        <td><a class="btn btn-primary" href="{% url 'show_video' instance.instance_id%}">Mostrar</a></td>
+                        <td><a class="btn btn-primary" href="{% url 'show_video' instance.instance_id%}">Visualizar</a></td>
+                        {% endif %}
                     </tr>
                     
                     {% if forloop.last and forloop.counter > 3 %}

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -110,7 +110,6 @@ Crawler "{{ crawler.source_name }}"
                         <td><button type="button" class="btn btn-primary" onclick="displayScreenshotModal({{instance.instance_id}})">Visualizar</button></td>
                         <td><a class="btn btn-primary" href="{% url 'export_config' instance.instance_id%}">Baixar</a></td>
                         <td><a class="btn btn-primary" href="{% url 'export_trace' instance.instance_id%}">Baixar</a></td>
-                        <td><a class="btn btn-primary" href="{% url 'show_video' instance.instance_id%}">Visualizar</a></td>
                         {% endif %}
                     </tr>
                     

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -91,7 +91,6 @@ Crawler "{{ crawler.source_name }}"
                         <th scope="col">Screenshots</th>
                         {% endif %}
                         <th scope="col">Arquivo de configurações</th>
-                        {% if crawler.dynamic_processing%}
                         <th scope="col">
                             Trace
                             <button type="button" class="popover-icon btn btn-link" data-toggle="popover" data-trigger="click" data-content=
@@ -103,7 +102,6 @@ Crawler "{{ crawler.source_name }}"
                                 <i class="fa fa-info-circle" aria-hidden="true"></i>
                             </button>
                         </th>
-                        {% endif %}
                     </tr>
                 </thead>
                 <tbody>
@@ -115,11 +113,9 @@ Crawler "{{ crawler.source_name }}"
                         <td>{{instance.duration_readable}}</td>
                         <td>{{instance.num_data_files}} arquivos</td>
                         <td>{{instance.data_size_readable}}</td>
-                        {% if crawler.dynamic_processing %}
                         <td><button type="button" class="btn btn-primary" onclick="displayScreenshotModal({{instance.instance_id}})">Visualizar</button></td>
                         <td><a class="btn btn-primary" href="{% url 'export_config' instance.instance_id%}">Baixar</a></td>
                         <td><a class="btn btn-primary" href="{% url 'export_trace' instance.instance_id%}">Baixar</a></td>
-                        {% endif %}
                     </tr>
                     
                     {% if forloop.last and forloop.counter > 3 %}

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -91,6 +91,9 @@ Crawler "{{ crawler.source_name }}"
                         <th scope="col">Screenshots</th>
                         {% endif %}
                         <th scope="col">Arquivo de configurações</th>
+                        {% if crawler.dynamic_processing and crawler.running == False %}
+                        <th scope="col">Trace</th>
+                        {% endif %}
                     </tr>
                 </thead>
                 <tbody>
@@ -106,6 +109,7 @@ Crawler "{{ crawler.source_name }}"
                         <td><button type="button" class="btn btn-primary" onclick="displayScreenshotModal({{instance.instance_id}})">Visualizar</button></td>
                         {% endif %}
                         <td><a class="btn btn-primary" href="{% url 'export_config' instance.instance_id%}">Baixar</a></td>
+                        <td><a class="btn btn-primary" href="{% url 'export_trace' instance.instance_id%}">Baixar</a></td>
                     </tr>
                     
                     {% if forloop.last and forloop.counter > 3 %}

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -91,7 +91,7 @@ Crawler "{{ crawler.source_name }}"
                         <th scope="col">Screenshots</th>
                         {% endif %}
                         <th scope="col">Arquivo de configurações</th>
-                        {% if crawler.dynamic_processing and crawler.running == False %}
+                        {% if crawler.dynamic_processing%}
                         <th scope="col">Trace</th>
                         <th scope="col">Vídeo</th>
                         {% endif %}

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -92,7 +92,17 @@ Crawler "{{ crawler.source_name }}"
                         {% endif %}
                         <th scope="col">Arquivo de configurações</th>
                         {% if crawler.dynamic_processing%}
-                        <th scope="col">Trace</th>
+                        <th scope="col">
+                            Trace
+                            <button type="button" class="popover-icon btn btn-link" data-toggle="popover" data-trigger="click" data-content=
+                                    "<p>Clique neste link para acessar a interface de execução do trace no seu navegador:</p>
+                                     <p>
+                                        <a href='https://trace.playwright.dev/' target='_blank'>https://playwright.dev/docs/trace-viewer</a>
+                                    </p>"
+                                    data-html="true">
+                                <i class="fa fa-info-circle" aria-hidden="true"></i>
+                            </button>
+                        </th>
                         {% endif %}
                     </tr>
                 </thead>

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -87,10 +87,9 @@ Crawler "{{ crawler.source_name }}"
                         <th scope="col">Duração</th>
                         <th scope="col">Nº de arquivos</th>
                         <th scope="col">Tamanho</th>
+                        <th scope="col">Arquivo de configurações</th>
                         {% if crawler.dynamic_processing %}
                         <th scope="col">Screenshots</th>
-                        {% endif %}
-                        <th scope="col">Arquivo de configurações</th>
                         <th scope="col">
                             Trace
                             <button type="button" class="popover-icon btn btn-link" data-toggle="popover" data-trigger="click" data-content=
@@ -102,6 +101,7 @@ Crawler "{{ crawler.source_name }}"
                                 <i class="fa fa-info-circle" aria-hidden="true"></i>
                             </button>
                         </th>
+                        {% endif %}
                     </tr>
                 </thead>
                 <tbody>
@@ -113,9 +113,11 @@ Crawler "{{ crawler.source_name }}"
                         <td>{{instance.duration_readable}}</td>
                         <td>{{instance.num_data_files}} arquivos</td>
                         <td>{{instance.data_size_readable}}</td>
-                        <td><button type="button" class="btn btn-primary" onclick="displayScreenshotModal({{instance.instance_id}})">Visualizar</button></td>
                         <td><a class="btn btn-primary" href="{% url 'export_config' instance.instance_id%}">Baixar</a></td>
+                        {% if crawler.dynamic_processing %}
+                        <td><button type="button" class="btn btn-primary" onclick="displayScreenshotModal({{instance.instance_id}})">Visualizar</button></td>
                         <td><a class="btn btn-primary" href="{% url 'export_trace' instance.instance_id%}">Baixar</a></td>
+                        {% endif %}
                     </tr>
                     
                     {% if forloop.last and forloop.counter > 3 %}

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -93,6 +93,7 @@ Crawler "{{ crawler.source_name }}"
                         <th scope="col">Arquivo de configurações</th>
                         {% if crawler.dynamic_processing and crawler.running == False %}
                         <th scope="col">Trace</th>
+                        <th scope="col">Vídeo</th>
                         {% endif %}
                     </tr>
                 </thead>
@@ -110,6 +111,7 @@ Crawler "{{ crawler.source_name }}"
                         {% endif %}
                         <td><a class="btn btn-primary" href="{% url 'export_config' instance.instance_id%}">Baixar</a></td>
                         <td><a class="btn btn-primary" href="{% url 'export_trace' instance.instance_id%}">Baixar</a></td>
+                        <td><a class="btn btn-primary" href="{% url 'show_video' instance.instance_id%}">Mostrar</a></td>
                     </tr>
                     
                     {% if forloop.last and forloop.counter > 3 %}

--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -93,7 +93,6 @@ Crawler "{{ crawler.source_name }}"
                         <th scope="col">Arquivo de configurações</th>
                         {% if crawler.dynamic_processing%}
                         <th scope="col">Trace</th>
-                        <th scope="col">Vídeo</th>
                         {% endif %}
                     </tr>
                 </thead>

--- a/main/urls.py
+++ b/main/urls.py
@@ -40,7 +40,6 @@ urlpatterns = [
     
     path("export_config/<str:instance_id>", views.export_config, name="export_config"),
     path("export_trace/<str:instance_id>", views.export_trace, name="export_trace"),
-    path("show_video/<str:instance_id>", views.show_video, name="show_video"),
 
     path("info/screenshots/<str:instance_id>/<int:page>", views.view_screenshots, name="view_screenshots"),
 

--- a/main/urls.py
+++ b/main/urls.py
@@ -40,7 +40,7 @@ urlpatterns = [
     
     path("export_config/<str:instance_id>", views.export_config, name="export_config"),
     path("export_trace/<str:instance_id>", views.export_trace, name="export_trace"),
-
+    path("show_video/<str:instance_id>", views.show_video, name="show_video"),
 
     path("info/screenshots/<str:instance_id>/<int:page>", views.view_screenshots, name="view_screenshots"),
 

--- a/main/urls.py
+++ b/main/urls.py
@@ -39,6 +39,7 @@ urlpatterns = [
     path("download/page/duplicated/<str:instance_id>", views.duplicated_download_page, name="duplicated_download_page"),
     
     path("export_config/<str:instance_id>", views.export_config, name="export_config"),
+    path("export_trace/<str:instance_id>", views.export_trace, name="export_trace"),
 
 
     path("info/screenshots/<str:instance_id>/<int:page>", views.view_screenshots, name="view_screenshots"),

--- a/main/views.py
+++ b/main/views.py
@@ -24,7 +24,6 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from scrapy_puppeteer import iframe_loader
-from wsgiref.util import FileWrapper
 
 from .forms import (CrawlRequestForm, ParameterHandlerFormSet,
                     RawCrawlRequestForm, ResponseHandlerFormSet)

--- a/main/views.py
+++ b/main/views.py
@@ -865,7 +865,7 @@ def export_trace(request, instance_id):
         response = FileResponse(open(path, 'rb'), content_type='zip')
     except FileNotFoundError:
         print(f"Arquivo Trace Não Encontrado: {file_name}. Verifique se a opção de gerar arquivo trace foi habilitada na configuração do coletor.")
-        return HttpResponseNotFound("<h1>Página Não Encontrada</h1>")
+        return HttpResponseNotFound("<h1>Página Não Encontrada</h1><p>Verifique se a opção de gerar arquivo trace foi habilitada na configuração do coletor.</p>")
     else:
         response['Content-Length'] = os.path.getsize(path)
         response['Content-Disposition'] = "attachment; filename=%s" % file_name
@@ -876,15 +876,16 @@ def show_video(request, instance_id):
     instance = get_object_or_404(CrawlerInstance, pk=instance_id)
     data_path = instance.crawler.data_path
 
-    file_name = f"{instance_id}.webm"
-    rel_path = os.path.join(data_path, str(instance_id), "debug", file_name)
-    path = os.path.join(settings.OUTPUT_FOLDER, rel_path)
+    rel_path = os.path.join(data_path, str(instance_id), "debug", "video")
+    file_name = os.listdir('rel_path')[0]
+    
+    path = os.path.join(settings.OUTPUT_FOLDER, rel_path, file_name)
 
     try:
         response = FileResponse(open(path, 'rb'), content_type='webm')
     except FileNotFoundError:
-        print(f"Vídeo Não Encontrado: {file_name}. Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.")
-        return HttpResponseNotFound("<h1>Página Não Encontrada</h1>")
+        print(f"Vídeo Não Encontrado. Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.")
+        return HttpResponseNotFound("<h1>Página Não Encontrada</h1><p>Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.</p>")
     else:
         response['Content-Length'] = os.path.getsize(path)
         response['Content-Disposition'] = "attachment; filename=%s" % file_name

--- a/main/views.py
+++ b/main/views.py
@@ -853,6 +853,24 @@ def export_config(request, instance_id):
 
     return response
 
+def export_trace(request, instance_id):
+    instance = get_object_or_404(CrawlerInstance, pk=instance_id)
+    data_path = instance.crawler.data_path
+
+    file_name = f"{instance_id}.zip"
+    rel_path = os.path.join(data_path, str(instance_id), "debug", file_name)
+    path = os.path.join(settings.OUTPUT_FOLDER, rel_path)
+
+    try:
+        response = FileResponse(open(path, 'rb'), content_type='zip')
+    except FileNotFoundError:
+        print(f"Arquivo Trace Não Encontrado: {file_name}. Verifique se a opção de gerar arquivo trace foi habilitada na configuração do coletor.")
+        return HttpResponseNotFound("<h1>Página Não Encontrada</h1>")
+    else:
+        response['Content-Length'] = os.path.getsize(path)
+        response['Content-Disposition'] = "attachment; filename=%s" % file_name
+
+    return response
 
 def view_screenshots(request, instance_id, page):
     IMGS_PER_PAGE = 20

--- a/main/views.py
+++ b/main/views.py
@@ -874,27 +874,6 @@ def export_trace(request, instance_id):
 
     return response
 
-def show_video(request, instance_id):
-    instance = get_object_or_404(CrawlerInstance, pk=instance_id)
-    data_path = instance.crawler.data_path
-
-    rel_path = os.path.join(data_path, str(instance_id), "debug", "video")
-    file_name = os.listdir(rel_path)[0]
-    
-    path = os.path.join(settings.OUTPUT_FOLDER, rel_path, file_name)
-
-    try:
-        file_wrapper = FileWrapper(open(path, 'rb'))
-        response = FileResponse(file_wrapper, content_type='video/webm')
-    except FileNotFoundError:
-        print(f"Vídeo Não Encontrado. Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.")
-        return HttpResponseNotFound("<h1>Página Não Encontrada</h1><p>Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.</p>")
-    else:
-        response['Content-Length'] = os.path.getsize(path)
-        response['Content-Disposition'] = "attachment; filename=%s" % file_name
-
-    return response
-
 def view_screenshots(request, instance_id, page):
     IMGS_PER_PAGE = 20
 

--- a/main/views.py
+++ b/main/views.py
@@ -858,13 +858,32 @@ def export_trace(request, instance_id):
     data_path = instance.crawler.data_path
 
     file_name = f"{instance_id}.zip"
-    rel_path = os.path.join(data_path, str(instance_id), "debug", file_name)
+    rel_path = os.path.join(data_path, str(instance_id), "debug", "trace", file_name)
     path = os.path.join(settings.OUTPUT_FOLDER, rel_path)
 
     try:
         response = FileResponse(open(path, 'rb'), content_type='zip')
     except FileNotFoundError:
         print(f"Arquivo Trace Não Encontrado: {file_name}. Verifique se a opção de gerar arquivo trace foi habilitada na configuração do coletor.")
+        return HttpResponseNotFound("<h1>Página Não Encontrada</h1>")
+    else:
+        response['Content-Length'] = os.path.getsize(path)
+        response['Content-Disposition'] = "attachment; filename=%s" % file_name
+
+    return response
+
+def show_video(request, instance_id):
+    instance = get_object_or_404(CrawlerInstance, pk=instance_id)
+    data_path = instance.crawler.data_path
+
+    file_name = f"{instance_id}.webm"
+    rel_path = os.path.join(data_path, str(instance_id), "debug", file_name)
+    path = os.path.join(settings.OUTPUT_FOLDER, rel_path)
+
+    try:
+        response = FileResponse(open(path, 'rb'), content_type='webm')
+    except FileNotFoundError:
+        print(f"Vídeo Não Encontrado: {file_name}. Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.")
         return HttpResponseNotFound("<h1>Página Não Encontrada</h1>")
     else:
         response['Content-Length'] = os.path.getsize(path)

--- a/main/views.py
+++ b/main/views.py
@@ -24,6 +24,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from scrapy_puppeteer import iframe_loader
+from wsgiref.util import FileWrapper
 
 from .forms import (CrawlRequestForm, ParameterHandlerFormSet,
                     RawCrawlRequestForm, ResponseHandlerFormSet)
@@ -32,6 +33,7 @@ from .models import (CRAWLER_QUEUE_DB_ID, CrawlerInstance, CrawlerQueue,
 from .serializers import (CrawlerInstanceSerializer, CrawlerQueueSerializer,
                           CrawlRequestSerializer, TaskSerializer)
 from .task_filter import task_filter_by_date_interval
+
 
 # Log the information to the file logger
 logger = logging.getLogger('file')
@@ -877,12 +879,13 @@ def show_video(request, instance_id):
     data_path = instance.crawler.data_path
 
     rel_path = os.path.join(data_path, str(instance_id), "debug", "video")
-    file_name = os.listdir('rel_path')[0]
+    file_name = os.listdir(rel_path)[0]
     
     path = os.path.join(settings.OUTPUT_FOLDER, rel_path, file_name)
 
     try:
-        response = FileResponse(open(path, 'rb'), content_type='webm')
+        file_wrapper = FileWrapper(open(path, 'rb'))
+        response = FileResponse(file_wrapper, content_type='video/webm')
     except FileNotFoundError:
         print(f"Vídeo Não Encontrado. Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.")
         return HttpResponseNotFound("<h1>Página Não Encontrada</h1><p>Verifique se a opção de gravação de vídeo foi habilitada na configuração do coletor.</p>")

--- a/spider_manager/src/crawling/spiders/static_page.py
+++ b/spider_manager/src/crawling/spiders/static_page.py
@@ -404,7 +404,7 @@ class StaticPageSpider(BaseSpider):
 
             if self.config['video_recording_enabled']:
                 context_kwargs['record_video_dir'] = os.path.join(instance_path, 'debug', 'video')
-                context_kwargs['record_video_size']= {"width": self.config["browser_resolution_width"], "height": self.config["browser_resolution_height"]}
+                context_kwargs['record_video_size'] = {"width": self.config["browser_resolution_width"], "height": self.config["browser_resolution_height"]}
           
             context = await browser.new_context(**context_kwargs)
 
@@ -429,7 +429,7 @@ class StaticPageSpider(BaseSpider):
             self.generate_file_descriptions(download_path)
 
             if self.config['create_trace_enabled']:
-                await context.tracing.stop(path = os.path.join(instance_path, 'debug', 'trace', 'trace.zip'))
+                await context.tracing.stop(path = os.path.join(instance_path, 'debug', 'trace', f"{instance_id}.zip"))
 
             await page.close()
             await browser.close()

--- a/spider_manager/src/crawling/spiders/static_page.py
+++ b/spider_manager/src/crawling/spiders/static_page.py
@@ -427,6 +427,12 @@ class StaticPageSpider(BaseSpider):
         for entry in list(page_dict.values()):
             results.append(self.page_to_response(entry, response))
 
+        # Maybe move this to the end of the whole parsing method
+        self.block_until_downloads_complete(download_path)
+        self.generate_file_descriptions(download_path)
+
+        await page.close()
+
         return results
 
     async def parse(self, response):

--- a/spider_manager/src/crawling/spiders/static_page.py
+++ b/spider_manager/src/crawling/spiders/static_page.py
@@ -444,12 +444,6 @@ class StaticPageSpider(BaseSpider):
         for entry in list(page_dict.values()):
             results.append(self.page_to_response(entry, response))
 
-        # Maybe move this to the end of the whole parsing method
-        self.block_until_downloads_complete(download_path)
-        self.generate_file_descriptions(download_path)
-
-        await page.close()
-
         return results
 
     async def parse(self, response):

--- a/spider_manager/src/crawling/spiders/static_page.py
+++ b/spider_manager/src/crawling/spiders/static_page.py
@@ -362,7 +362,6 @@ class StaticPageSpider(BaseSpider):
 
         data_path = self.config['data_path']
         skip_iter_errors = self.config['skip_iter_errors']
-        headless = not self.config['headful_enabled']
 
         output_folder = self.settings['OUTPUT_FOLDER']
         instance_path = os.path.join(output_folder, data_path,
@@ -382,13 +381,13 @@ class StaticPageSpider(BaseSpider):
             browser = None
 
             if self.config["browser_type"] == 'chromium':
-                browser = await p.chromium.launch(headless=headless,
+                browser = await p.chromium.launch(headless=True,
                     downloads_path=temp_download_path)
             elif self.config["browser_type"] == 'webkit':
-                browser = await p.webkit.launch(headless=headless,
+                browser = await p.webkit.launch(headless=True,
                     downloads_path=temp_download_path)
             elif self.config["browser_type"] == 'firefox':
-                browser = await p.firefox.launch(headless=headless,
+                browser = await p.firefox.launch(headless=True,
                     downloads_path=temp_download_path)
 
             normalized_headers = request.headers.to_unicode_dict()

--- a/spider_manager/src/crawling/spiders/static_page.py
+++ b/spider_manager/src/crawling/spiders/static_page.py
@@ -431,8 +431,8 @@ class StaticPageSpider(BaseSpider):
                 await context.tracing.stop(path = os.path.join(instance_path, 'debug', 'trace', f"{instance_id}.zip"))
 
             await page.close()
-            await browser.close()
             await context.close()
+            await browser.close()
 
         # Necessary to bypass the compression middleware (?)
         response.headers.pop('content-encoding', None)


### PR DESCRIPTION
Inclusão da opção de criar o arquivo `trace.zip` da execução do processamento dinâmico do coletor, além da opção de gravar vídeos da execução do coletor, feature especificada em #7711 . Estas opções se encontram na página de configuração do "Processamento Dinâmico".

![image](https://user-images.githubusercontent.com/48096245/204640311-c5a41216-2ff6-4984-bd51-9e98ea3429b3.png)


O acesso ao trace pode ser realizado baixando o arquivo na interface (na página de detalhes da execução) ou na pasta `/debug/trace`. O arquivo pode ser executado via terminal, com `python -m playwright show-trace trace.zip` ou através da plataforma oficial https://trace.playwright.dev/.

![image](https://user-images.githubusercontent.com/48096245/204640436-c1429bfc-3c60-4e87-a149-f84a375b400a.png)


O vídeo pode ser acessado em `/debug/video`, está em formato `.webm`. Caso seu executor de vídeo local não aceite esse formato de vídeo, você pode assistí-lo abrindo em seu navegador.

Closes #4798