### PR TITLE
Issue 7766 - Erro em coleta de dados das despesas de Montes Claros

### DIFF
--- a/main/templates/main/detail_crawler.html
+++ b/main/templates/main/detail_crawler.html
@@ -172,7 +172,7 @@ Crawler "{{ crawler.source_name }}"
     <!-- Tail stdout -->
     <div class="row">
         <div class="col">
-            <div class="row">
+            <!-- <div class="row">
                 <div class="col-12 pr-0">
                     <hr>
                     <h5>Progresso de coleta de páginas</h5>
@@ -235,7 +235,7 @@ Crawler "{{ crawler.source_name }}"
                     </div>
                     <hr class="my-4">
                 </div>
-            </div>
+            </div> -->
             <div class="row mb-3">
                 <div class="col pr-0 d-flex align-items-center justify-content-between">
                     <h5>Últimas linhas do stdout</h5>

--- a/spider_manager/src/crawling/distributed_scheduler.py
+++ b/spider_manager/src/crawling/distributed_scheduler.py
@@ -488,19 +488,6 @@ class DistributedScheduler(object):
                 if not request_seen:
                     notify_new_page_found(req_dict['meta']['attrs']['instance_id'])
 
-                # Remove Playwright keys from request
-                if "meta" in req_dict:
-                    if "playwright" in req_dict["meta"]:
-                        del req_dict["meta"]["playwright"]
-                    if "playwright_include_page" in req_dict["meta"]:
-                        del req_dict["meta"]["playwright_include_page"]
-                    if "playwright_context" in req_dict["meta"]:
-                        del req_dict["meta"]["playwright_context"]
-                    if "playwright_page" in req_dict["meta"]:
-                        del req_dict["meta"]["playwright_page"]
-                    if "playwright_security_details" in req_dict["meta"]:
-                        del req_dict["meta"]["playwright_security_details"]
-
                 clean_dict = decode_binary_entry(req_dict.copy())
 
                 # we may already have the queue in memory
@@ -604,10 +591,8 @@ class DistributedScheduler(object):
                 method=req_method,
                 dont_filter=True,
                 meta={
-                    "playwright": True,
-                    "playwright_include_page": True,
                     "steps": steps
-            }
+                }
             )
         else:
             try:

--- a/spider_manager/src/crawling/items.py
+++ b/spider_manager/src/crawling/items.py
@@ -26,3 +26,4 @@ class RawResponseItem(Item):
     files_found = Field()
     images_found = Field()
     attrs = Field()
+    dynamic_finished = Field()

--- a/spider_manager/src/crawling/items.py
+++ b/spider_manager/src/crawling/items.py
@@ -26,4 +26,3 @@ class RawResponseItem(Item):
     files_found = Field()
     images_found = Field()
     attrs = Field()
-    dynamic_finished = Field()

--- a/spider_manager/src/crawling/spiders/static_page.py
+++ b/spider_manager/src/crawling/spiders/static_page.py
@@ -489,6 +489,5 @@ class StaticPageSpider(BaseSpider):
                 continue
 
             item = self.response_to_item(response, files_found, images_found, idx)
-            item["dynamic_finished"] = True
 
             yield item


### PR DESCRIPTION
Resolve problema de coleta em Montes Claros. As seguintes alterações foram feitas:

- Adiciona verificação que garante execução do navegador apenas nas requisições iniciais (após extração de links as coletas devem seguir o fluxo da coleta estática)
- Utiliza nomes diferentes para pasta temporária de download do navegador e pasta temporária de downloads estáticos (navegador e módulo writer usavam o nome `temp`, que gerava conflitos onde, caso o navegador encerre antes das extrações estáticas terminarem, a pasta era deletada enquanto o writer ainda estava a utilizando)
- Remove alguns parâmetros remanescentes do Scrapy-Playwright nas requisições
- Comenta a barra de progresso na interface para ocultá-la temporariamente

Closes #7766, #8017.