### PR TITLE
Issue 8220 - Corrige número de arquivos baixados na interface

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -181,12 +181,9 @@ def process_stop_crawl(crawler_id, from_sm_listener: bool = False):
     # parts = output_line.split('\t')
     data_size_kbytes = 0  # int(parts[0])
 
-    # FIXME: Colocar esse trecho de código no módulo writer
-    # conta a qtde de arquivos no diretório "data"
-    # command_output = subprocess.run(
-    #     ["find " + config['data_path'] + "/data -type f | wc -l"], shell=True, stdout=subprocess.PIPE)
-    # output_line = command_output.stdout.decode('utf-8').strip('\n')
-    num_data_files = 0  # int(output_line)
+    # Get the number of files downloaded from the instance object
+    num_data_files = instance.number_files_success_download
+    
 
     instance = None
     instance_info = {}


### PR DESCRIPTION
A correção foi feita utilizando um atributo já existente na instância. Para testar, basta rodar um coletor que faça download de arquivos e após o seu término, checar se na interface é apresentado o número de arquivos baixados. 

fixes #8220 